### PR TITLE
fix: do not throw error when resolving symlink of a plain directory

### DIFF
--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -574,6 +574,17 @@ public struct FileSystem: FileSysteming, Sendable {
         if !(try await exists(symlinkPath)) {
             throw FileSystemError.absentSymbolicLink(symlinkPath)
         }
+        guard let info = try await NIOFileSystem.FileSystem.shared.info(
+            forFileAt: FilePath(symlinkPath.pathString),
+            infoAboutSymbolicLink: true
+        )
+        else { return symlinkPath }
+        switch info.type {
+        case .symlink:
+            break
+        default:
+            return symlinkPath
+        }
         let path = try await NIOFileSystem.FileSystem.shared.destinationOfSymbolicLink(at: FilePath(symlinkPath.pathString))
         return try AbsolutePath(validating: path.string)
     }

--- a/Tests/FileSystemTests/FileSystemTests.swift
+++ b/Tests/FileSystemTests/FileSystemTests.swift
@@ -416,6 +416,20 @@ final class FileSystemTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    func test_resolveSymbolicLink_whenThePathIsNotASymbolicLink() async throws {
+        try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+            // Given
+            let directoryPath = temporaryDirectory.appending(component: "symbolic")
+            try await subject.makeDirectory(at: directoryPath)
+
+            // When
+            let got = try await subject.resolveSymbolicLink(directoryPath)
+
+            // Then
+            XCTAssertEqual(got, directoryPath)
+        }
+    }
+
     func test_zipping() async throws {
         try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
             // Given


### PR DESCRIPTION
As of now, `resolveSymbolicLink` throws an error if the passed path is not a symbolic link.

For `tuist/tuist` purposes, we often don't know if a given path is or is not symbolic link since it depends on the user input or specific `xcodebuild` behavior.

I believe it's better to simply return the path without resolving if the file/directory is _not_ a symlink instead of throwing. 

Alternatively, we could add an `isSymbolicLink` method and let the consumers of the library ensure `resolveSymbolicLink` is called only for actual symlinks. But in `tuist/tuist`, we would have to do this dance almost everywhere we end up using `resolveSymbolicLink`, which is why I'm leaning to the former.