### PR TITLE
Fix glob returning paths with resolved symlinks

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/swift-glob",
       "state" : {
-        "revision" : "8b440700f129dd3d5440ef3eb5e84c0619f2f4a8",
-        "version" : "0.2.1"
+        "revision" : "a0bc22cc5e5113356d31540dbe66da0b653cd6d8",
+        "version" : "0.2.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/swift-glob",
       "state" : {
-        "revision" : "6f1f051f28f4ff47f28a94d7f9c28ac323555deb",
-        "version" : "0.2.0"
+        "revision" : "8b440700f129dd3d5440ef3eb5e84c0619f2f4a8",
+        "version" : "0.2.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -30,10 +30,10 @@
     {
       "identity" : "swift-glob",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/davbeck/swift-glob",
+      "location" : "https://github.com/tuist/swift-glob",
       "state" : {
-        "revision" : "f8d3495325bfd1a53f37ece5a244f28d1d857879",
-        "version" : "0.1.0"
+        "revision" : "6f1f051f28f4ff47f28a94d7f9c28ac323555deb",
+        "version" : "0.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.74.0")),
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.6.1")),
         .package(url: "https://github.com/weichsel/ZIPFoundation", .upToNextMajor(from: "0.9.19")),
-        .package(url: "https://github.com/tuist/swift-glob", .upToNextMajor(from: "0.2.1")),
+        .package(url: "https://github.com/tuist/swift-glob", .upToNextMajor(from: "0.2.2")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.74.0")),
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.6.1")),
         .package(url: "https://github.com/weichsel/ZIPFoundation", .upToNextMajor(from: "0.9.19")),
+        // We're depending on a fork until the following PR is merged: https://github.com/davbeck/swift-glob/pull/14
         .package(url: "https://github.com/tuist/swift-glob", .upToNextMajor(from: "0.2.2")),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.74.0")),
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.6.1")),
         .package(url: "https://github.com/weichsel/ZIPFoundation", .upToNextMajor(from: "0.9.19")),
-        .package(url: "https://github.com/tuist/swift-glob", .upToNextMajor(from: "0.2.0")),
+        .package(url: "https://github.com/tuist/swift-glob", .upToNextMajor(from: "0.2.1")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.74.0")),
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.6.1")),
         .package(url: "https://github.com/weichsel/ZIPFoundation", .upToNextMajor(from: "0.9.19")),
-        .package(url: "https://github.com/davbeck/swift-glob", .upToNextMajor(from: "0.1.0")),
+        .package(url: "https://github.com/tuist/swift-glob", .upToNextMajor(from: "0.2.0")),
     ],
     targets: [
         .target(

--- a/Tests/FileSystemTests/FileSystemTests.swift
+++ b/Tests/FileSystemTests/FileSystemTests.swift
@@ -487,6 +487,31 @@ final class FileSystemTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    func test_glob_when_recursive_glob_with_file_being_in_the_base_directory() async throws {
+        try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+            print(temporaryDirectory)
+            let temporaryDirectory = try AbsolutePath(validating: temporaryDirectory.pathString.replacingOccurrences(
+                of: "/private",
+                with: ""
+            ))
+            // Given
+            let firstSourceFile = temporaryDirectory.appending(component: "first.swift")
+
+            try await subject.touch(firstSourceFile)
+
+            // When
+            let got = try await subject.glob(
+                directory: temporaryDirectory,
+                include: ["*.swift"]
+            )
+            .collect()
+            .sorted()
+
+            // Then
+            XCTAssertEqual(got, [firstSourceFile])
+        }
+    }
+
     func test_glob_when_not_excluding_hidden_files() async throws {
         try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
             // Given

--- a/Tests/FileSystemTests/FileSystemTests.swift
+++ b/Tests/FileSystemTests/FileSystemTests.swift
@@ -487,30 +487,33 @@ final class FileSystemTests: XCTestCase, @unchecked Sendable {
         }
     }
 
-    func test_glob_when_recursive_glob_with_file_being_in_the_base_directory() async throws {
-        try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
-            print(temporaryDirectory)
-            let temporaryDirectory = try AbsolutePath(validating: temporaryDirectory.pathString.replacingOccurrences(
-                of: "/private",
-                with: ""
-            ))
-            // Given
-            let firstSourceFile = temporaryDirectory.appending(component: "first.swift")
+    // The following behavior works correctly only on Apple environments due to discrepancies in the `Foundation` implementation.
+    #if !os(Linux)
+        func test_glob_when_recursive_glob_with_file_being_in_the_base_directory() async throws {
+            try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+                print(temporaryDirectory)
+                let temporaryDirectory = try AbsolutePath(validating: temporaryDirectory.pathString.replacingOccurrences(
+                    of: "/private",
+                    with: ""
+                ))
+                // Given
+                let firstSourceFile = temporaryDirectory.appending(component: "first.swift")
 
-            try await subject.touch(firstSourceFile)
+                try await subject.touch(firstSourceFile)
 
-            // When
-            let got = try await subject.glob(
-                directory: temporaryDirectory,
-                include: ["*.swift"]
-            )
-            .collect()
-            .sorted()
+                // When
+                let got = try await subject.glob(
+                    directory: temporaryDirectory,
+                    include: ["*.swift"]
+                )
+                .collect()
+                .sorted()
 
-            // Then
-            XCTAssertEqual(got, [firstSourceFile])
+                // Then
+                XCTAssertEqual(got, [firstSourceFile])
+            }
         }
-    }
+    #endif
 
     func test_glob_when_not_excluding_hidden_files() async throws {
         try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in


### PR DESCRIPTION
Moved to a fork until this [fix](https://github.com/davbeck/swift-glob/pull/14) is merged.