### PR TITLE
fix: glob returning paths with resolved symlinks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.76.0")),
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.6.1")),
         .package(url: "https://github.com/weichsel/ZIPFoundation", .upToNextMajor(from: "0.9.19")),
-        // We're depending on a fork until the following PR is merged: https://github.com/davbeck/swift-glob/pull/14
+        // We are depending on a fork until the following PR is merged: https://github.com/davbeck/swift-glob/pull/14
         .package(url: "https://github.com/tuist/swift-glob", .upToNextMajor(from: "0.2.2")),
     ],
     targets: [


### PR DESCRIPTION
Trying to trigger a release as the previous PRs were missing the conventional commits