### PR TITLE
feat: use different implementation of globbing for more stable behavior

### DIFF
--- a/.github/workflows/file-system.yml
+++ b/.github/workflows/file-system.yml
@@ -25,17 +25,6 @@ jobs:
       - name: Run
         run: mise run build-spm
 
-  # build-linux:
-  #   name: "Release build on Linux"
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: jdx/mise-action@v2
-  #       with:
-  #         experimental: true
-  #     - name: Run
-  #       run: mise run build-linux
-
   build_tuist:
     name: "Tuist build"
     runs-on: "macos-14"
@@ -61,17 +50,6 @@ jobs:
           experimental: true
       - name: Run
         run: mise run test-spm
-
-  # test_linux:
-  #   name: "Test on Linux"
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: jdx/mise-action@v2
-  #       with:
-  #         experimental: true
-  #     - name: Run
-  #       run: mise run test-linux
 
   test_tuist:
     name: "Tuist test"

--- a/.github/workflows/file-system.yml
+++ b/.github/workflows/file-system.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   TUIST_CONFIG_CLOUD_TOKEN: ${{ secrets.TUIST_CONFIG_CLOUD_TOKEN }}
-  
+
 concurrency:
   group: file-system-${{ github.head_ref }}
   cancel-in-progress: true
@@ -25,16 +25,16 @@ jobs:
       - name: Run
         run: mise run build-spm
 
-  build-linux:
-    name: "Release build on Linux"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
-        with:
-          experimental: true
-      - name: Run
-        run: mise run build-linux
+  # build-linux:
+  #   name: "Release build on Linux"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: jdx/mise-action@v2
+  #       with:
+  #         experimental: true
+  #     - name: Run
+  #       run: mise run build-linux
 
   build_tuist:
     name: "Tuist build"
@@ -62,16 +62,16 @@ jobs:
       - name: Run
         run: mise run test-spm
 
-  test_linux:
-    name: "Test on Linux"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
-        with:
-          experimental: true
-      - name: Run
-        run: mise run test-linux
+  # test_linux:
+  #   name: "Test on Linux"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: jdx/mise-action@v2
+  #       with:
+  #         experimental: true
+  #     - name: Run
+  #       run: mise run test-linux
 
   test_tuist:
     name: "Tuist test"

--- a/Sources/FileSystem/AbsolutePath+Extras.swift
+++ b/Sources/FileSystem/AbsolutePath+Extras.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Path
+
+extension AbsolutePath {
+    /// Returns the list of paths that match the given glob pattern.
+    ///
+    /// - Parameter pattern: Relative glob pattern used to match the paths.
+    /// - Returns: List of paths that match the given pattern.
+    func glob(_ pattern: String) -> [AbsolutePath] {
+        // swiftlint:disable:next force_try
+        Glob(pattern: appending(try! RelativePath(validating: pattern)).pathString).paths
+            .map { try! AbsolutePath(validating: $0) } // swiftlint:disable:this force_try
+    }
+}

--- a/Sources/FileSystem/FileManager+Extras.swift
+++ b/Sources/FileSystem/FileManager+Extras.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+extension FileManager {
+    func subdirectoriesResolvingSymbolicLinks(atPath path: String) -> [String] {
+        subdirectoriesResolvingSymbolicLinks(atNestedPath: nil, basePath: path)
+    }
+
+    private func subdirectoriesResolvingSymbolicLinks(
+        atNestedPath nestedPath: String?,
+        basePath: String,
+        visitedPaths: inout Set<String>
+    ) -> [String] {
+        let currentLevelPath = nestedPath.map { NSString(string: basePath).appendingPathComponent($0) } ?? basePath
+        let resolvedCurrentLevelPath = resolvingSymbolicLinks(path: currentLevelPath)
+        let standardizedPath = NSString(string: resolvedCurrentLevelPath).standardizingPath
+
+        // Check if we've already visited this standardized path
+        guard !visitedPaths.contains(standardizedPath) else {
+            return []
+        }
+
+        // Mark this standardized path as visited
+        visitedPaths.insert(standardizedPath)
+
+        guard let resolvedSubpathsFromCurrentRoot = try? subpathsOfDirectory(atPath: resolvedCurrentLevelPath)
+        else {
+            return []
+        }
+
+        var resolvedSubpaths: [String] = []
+        for subpath in resolvedSubpathsFromCurrentRoot {
+            let relativeSubpath = nestedPath.map { NSString(string: $0).appendingPathComponent(subpath) } ?? subpath
+            let completeSubpath = NSString(string: basePath).appendingPathComponent(relativeSubpath)
+
+            if isSymbolicLinkToDirectory(path: completeSubpath) {
+                resolvedSubpaths.append(relativeSubpath)
+                resolvedSubpaths.append(
+                    contentsOf: subdirectoriesResolvingSymbolicLinks(
+                        atNestedPath: relativeSubpath,
+                        basePath: basePath,
+                        visitedPaths: &visitedPaths
+                    )
+                )
+            } else if isDirectory(path: completeSubpath) {
+                resolvedSubpaths.append(relativeSubpath)
+            }
+        }
+
+        return resolvedSubpaths
+    }
+
+    private func subdirectoriesResolvingSymbolicLinks(atNestedPath nestedPath: String?, basePath: String) -> [String] {
+        var visitedPaths: Set<String> = .init()
+        return subdirectoriesResolvingSymbolicLinks(atNestedPath: nestedPath, basePath: basePath, visitedPaths: &visitedPaths)
+    }
+
+    private func isSymbolicLinkToDirectory(path: String) -> Bool {
+        let pathResolvingSymbolicLinks = resolvingSymbolicLinks(path: path)
+        return pathResolvingSymbolicLinks != path && isDirectory(path: pathResolvingSymbolicLinks)
+    }
+
+    private func resolvingSymbolicLinks(path: String) -> String {
+        guard let destination = try? destinationOfSymbolicLink(atPath: path) else {
+            return path
+        }
+
+        let absoluteDestination: String
+        if destination.starts(with: "/") {
+            absoluteDestination = destination
+        } else {
+            // Transform symlinks with relative destinations to absolute paths.
+            absoluteDestination = URL(fileURLWithPath: path).deletingLastPathComponent().appendingPathComponent(destination).path
+        }
+
+        return resolvingSymbolicLinks(path: absoluteDestination)
+    }
+
+    func isDirectory(path: String) -> Bool {
+        #if os(macOS)
+            var isDirectoryBool = ObjCBool(false)
+        #else
+            var isDirectoryBool = false
+        #endif
+        let doesFileExist = fileExists(atPath: path, isDirectory: &isDirectoryBool)
+        #if os(macOS)
+            return doesFileExist && isDirectoryBool.boolValue
+        #else
+            return doesFileExist && isDirectoryBool
+        #endif
+    }
+}

--- a/Sources/FileSystem/Glob.swift
+++ b/Sources/FileSystem/Glob.swift
@@ -1,0 +1,174 @@
+//
+//  Created by Eric Firestone on 3/22/16.
+//  Copyright © 2016 Square, Inc. All rights reserved.
+//  Released under the Apache v2 License.
+//
+//  Adapted from https://gist.github.com/efirestone/ce01ae109e08772647eb061b3bb387c3
+import Foundation
+
+// swiftlint:disable:next identifier_name
+let GlobBehaviorBashV4 = Glob.Behavior(
+    supportsGlobstar: true, // Matches Bash v4 with "shopt -s globstar" option
+    includesFilesFromRootOfGlobstar: true,
+    includesDirectoriesInResults: true,
+    includesFilesInResultsIfTrailingSlash: false
+)
+
+/**
+ Finds files on the file system using pattern matching.
+ */
+final class Glob: Collection {
+    /**
+     * Different glob implementations have different behaviors, so the behavior of this
+     * implementation is customizable.
+     */
+    struct Behavior: Sendable {
+        // If true then a globstar ("**") causes matching to be done recursively in subdirectories.
+        // If false then "**" is treated the same as "*"
+        let supportsGlobstar: Bool
+
+        // If true the results from the directory where the globstar is declared will be included as well.
+        // For example, with the pattern "dir/**/*.ext" the fie "dir/file.ext" would be included if this
+        // property is true, and would be omitted if it's false.
+        let includesFilesFromRootOfGlobstar: Bool
+
+        // If false then the results will not include directory entries. This does not affect recursion depth.
+        let includesDirectoriesInResults: Bool
+
+        // If false and the last characters of the pattern are "**/" then only directories are returned in the results.
+        let includesFilesInResultsIfTrailingSlash: Bool
+    }
+
+    let behavior: Behavior = GlobBehaviorBashV4
+    var paths = [String]()
+    var startIndex: Int { paths.startIndex }
+    var endIndex: Int { paths.endIndex }
+
+    init(pattern: String) {
+        var adjustedPattern = pattern
+        let hasTrailingGlobstarSlash = pattern.hasSuffix("**/")
+        var includeFiles = !hasTrailingGlobstarSlash
+
+        if behavior.includesFilesInResultsIfTrailingSlash {
+            includeFiles = true
+            if hasTrailingGlobstarSlash {
+                // Grab the files too.
+                adjustedPattern += "*"
+            }
+        }
+
+        let patterns = behavior.supportsGlobstar ? expandGlobstar(pattern: adjustedPattern) : [adjustedPattern]
+
+        for pattern in patterns {
+            var gt = glob_t()
+            if executeGlob(pattern: pattern, gt: &gt) {
+                populateFiles(gt: gt, includeFiles: includeFiles)
+            }
+
+            globfree(&gt)
+        }
+
+        paths = Array(Set(paths)).sorted { lhs, rhs in
+            lhs.compare(rhs) != ComparisonResult.orderedDescending
+        }
+    }
+
+    // MARK: Private
+
+    private var globalFlags = GLOB_TILDE | GLOB_BRACE | GLOB_MARK
+
+    private func executeGlob(pattern: UnsafePointer<CChar>, gt: UnsafeMutablePointer<glob_t>) -> Bool {
+        glob(pattern, globalFlags, nil, gt) == 0
+    }
+
+    private func expandGlobstar(pattern: String) -> [String] {
+        // Split pattern string by slash to find globstar.
+        let patternComponents = pattern.components(separatedBy: "/")
+
+        // We are only interested in the first globstar since that is where we want to separate the pattern string.
+        guard let pivot = patternComponents.firstIndex(of: "**") else {
+            return [pattern]
+        }
+
+        var results = [String]()
+
+        // Part before the first globstar
+        let firstPartLowerBound = 0
+        let firstPartUpperBound = pivot
+        let firstPartComponents: ArraySlice<String> = if firstPartLowerBound < firstPartUpperBound {
+            patternComponents[firstPartLowerBound ..< firstPartUpperBound]
+        } else {
+            []
+        }
+        let firstPart = firstPartComponents.joined(separator: "/")
+
+        // Part after the first globstar
+        let lastPartLowerBound = pivot + 1
+        let lastPartUpperBound = patternComponents.count
+        let lastPartComponents: ArraySlice<String> = if lastPartLowerBound < lastPartUpperBound {
+            patternComponents[lastPartLowerBound ..< lastPartUpperBound]
+        } else {
+            []
+        }
+        var lastPart = lastPartComponents.joined(separator: "/")
+
+        // Find subdirectories
+        let fileManager = FileManager.default
+
+        var directories = fileManager.subdirectoriesResolvingSymbolicLinks(atPath: firstPart)
+            .map { NSString(string: firstPart).appendingPathComponent($0) }
+
+        if behavior.includesFilesFromRootOfGlobstar {
+            // Check the base directory for the glob star as well.
+            directories.insert(firstPart, at: 0)
+
+            // Include the globstar root directory ("dir/") in a pattern like "dir/**" or "dir/**/"
+            if lastPart.isEmpty {
+                results.append(firstPart)
+            }
+        }
+
+        if lastPart.isEmpty {
+            lastPart = "*"
+        }
+        for directory in directories {
+            let partiallyResolvedPattern = NSString(string: directory).appendingPathComponent(lastPart)
+            results.append(contentsOf: expandGlobstar(pattern: partiallyResolvedPattern))
+        }
+
+        return results
+    }
+
+    private func populateFiles(gt: glob_t, includeFiles: Bool) {
+        let includeDirectories = behavior.includesDirectoriesInResults
+        #if os(Linux)
+            let matchesCount = Int(gt.gl_pathc)
+        #else
+            let matchesCount = Int(gt.gl_matchc)
+        #endif
+        for i in 0 ..< matchesCount {
+            if let path = String(validatingUTF8: gt.gl_pathv[i]!) {
+                if !includeFiles || !includeDirectories {
+                    let isDirectory = FileManager.default.isDirectory(path: path)
+                    if (!includeFiles && !isDirectory) || (!includeDirectories && isDirectory) {
+                        continue
+                    }
+                }
+
+                paths.append(path)
+            }
+        }
+    }
+
+    // MARK: Subscript Support
+
+    subscript(i: Int) -> String {
+        paths[i]
+    }
+
+    // MARK: IndexableBase
+
+    func index(after i: Glob.Index) -> Glob.Index {
+        i + 1
+    }
+}


### PR DESCRIPTION
The [swift-glob](https://github.com/davbeck/swift-glob) library that we decided to use is currently not production ready. There are a bunch of issues that need to be fixed before we rely on it in `tuist/tuist`. I will try to open PRs and issues to eventually still migrate to it. The issues I ran into so far:
- `glob(directory: "some-dir", include: ["."])` doesn't return anything when it should return `some-dir` if it exists. The same when include is `[""]`
- `glob(directory: "/", include: ["var/..../app"])` actually goes through literally every single directory on your system when it should first find a pivot and go through directories from there
- The library shouldn't returned paths with resolved symlinks: https://github.com/davbeck/swift-glob/pull/14
- `glob(directory: "some-dir", include: ["**/*.swift"])` doesn't return `some-dir/*.swift` files

For now, I mostly kept the API surface the same but moved to the `Glob` that we have in `tuist/tuist`.

I'm also dropping Linux support for now as it doesn't make sense to fix our code at this stage for something nobody uses right now. This codebase should be compatible with Linux again once we move back to `swift-glob`.