### PR TITLE
fix: include hidden files by default

### DIFF
--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -608,7 +608,8 @@ public struct FileSystem: FileSysteming, Sendable {
             directory: URL(string: directory.pathString)!,
             include: try include
                 .flatMap { $0.contains("**/") ? [$0.replacingOccurrences(of: "**/", with: ""), $0] : [$0] }
-                .map { try Pattern($0) }
+                .map { try Pattern($0) },
+            skipHiddenFiles: false
         )
         .map {
             let path = $0.absoluteString.replacingOccurrences(of: "file://", with: "")

--- a/Tests/FileSystemTests/FileSystemTests.swift
+++ b/Tests/FileSystemTests/FileSystemTests.swift
@@ -697,6 +697,27 @@ final class FileSystemTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    func test_glob_with_hidden_file_and_extension_wildcard() async throws {
+        try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+            // Given
+            let directory = temporaryDirectory.appending(component: "directory")
+            let sourceFile = directory.appending(component: ".hidden.swift")
+            try await subject.makeDirectory(at: directory)
+            try await subject.touch(sourceFile)
+
+            // When
+            let got = try await subject.glob(
+                directory: directory,
+                include: [".*.swift"]
+            )
+            .collect()
+            .sorted()
+
+            // Then
+            XCTAssertEqual(got, [sourceFile])
+        }
+    }
+
     func test_glob_with_constant_file() async throws {
         try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
             // Given


### PR DESCRIPTION
Aligning with the previous implementation of globbing that included hidden files by default.