### PR TITLE
fix: searching for files in symlinked directories

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/swift-glob",
       "state" : {
-        "revision" : "c086760260c4bd6541ea42fdbb8cc76a9798b3fa",
-        "version" : "0.3.6"
+        "revision" : "106ff5ea97cca6ee504765133af3175ecd5ca257",
+        "version" : "0.3.7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/weichsel/ZIPFoundation", .upToNextMajor(from: "0.9.19")),
         // We are depending on a fork as swift-glob currently can't handle some scenario that we need in tuist/tuist.
         // For example, the package currently goes through all directories regradless of whether that's necessary.'
-        .package(url: "https://github.com/tuist/swift-glob", .upToNextMajor(from: "0.3.6")),
+        .package(url: "https://github.com/tuist/swift-glob", .upToNextMajor(from: "0.3.7")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Searching for files through directory symlinks wouldn't find those. The updated version of `swift-glob` has a fix for this.