### PR TITLE
fix: path wildcard with constant component

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/swift-glob",
       "state" : {
-        "revision" : "4762b314c3ade2f2e3d36ab5cd0817bcd952d653",
-        "version" : "0.3.8"
+        "revision" : "6e828ca92cb8b31a15f31bdd4edccc6d30017ee3",
+        "version" : "0.3.9"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/weichsel/ZIPFoundation", .upToNextMajor(from: "0.9.19")),
         // We are depending on a fork as swift-glob currently can't handle some scenario that we need in tuist/tuist.
         // For example, the package currently goes through all directories regradless of whether that's necessary.'
-        .package(url: "https://github.com/tuist/swift-glob", .upToNextMajor(from: "0.3.8")),
+        .package(url: "https://github.com/tuist/swift-glob", .upToNextMajor(from: "0.3.9")),
     ],
     targets: [
         .target(

--- a/Tests/FileSystemTests/FileSystemTests.swift
+++ b/Tests/FileSystemTests/FileSystemTests.swift
@@ -739,6 +739,27 @@ final class FileSystemTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    func test_glob_with_path_wildcard() async throws {
+        try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+            // Given
+            let directory = temporaryDirectory.appending(component: "directory")
+            let sourceFile = directory.appending(component: "first.swift")
+            try await subject.makeDirectory(at: directory)
+            try await subject.touch(sourceFile)
+
+            // When
+            let got = try await subject.glob(
+                directory: directory,
+                include: ["**/first.swift"]
+            )
+            .collect()
+            .sorted()
+
+            // Then
+            XCTAssertEqual(got, [sourceFile])
+        }
+    }
+
     func test_glob_with_nested_files_and_only_a_directory_wildcard() async throws {
         try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
             // Given


### PR DESCRIPTION
Fix matching file directly in a directory with a pattern such as `**/name-of-file.swift`