### PR TITLE
refactor: migrate used subset of swift-glob to FileSystem

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -28,15 +28,6 @@
       }
     },
     {
-      "identity" : "swift-glob",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tuist/swift-glob",
-      "state" : {
-        "revision" : "6e828ca92cb8b31a15f31bdd4edccc6d30017ee3",
-        "version" : "0.3.9"
-      }
-    },
-    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",

--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version: 5.8.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
-import PackageDescription
+@preconcurrency import PackageDescription
 
 #if TUIST
     import ProjectDescription
@@ -29,17 +29,14 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.76.1")),
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.6.1")),
         .package(url: "https://github.com/weichsel/ZIPFoundation", .upToNextMajor(from: "0.9.19")),
-        // We are depending on a fork as swift-glob currently can't handle some scenario that we need in tuist/tuist.
-        // For example, the package currently goes through all directories regradless of whether that's necessary.'
-        .package(url: "https://github.com/tuist/swift-glob", .upToNextMajor(from: "0.3.9")),
     ],
     targets: [
         .target(
             name: "FileSystem",
             dependencies: [
+                "Glob",
                 .product(name: "_NIOFileSystem", package: "swift-nio"),
                 .product(name: "Path", package: "Path"),
-                .product(name: "Glob", package: "swift-glob"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "ZIPFoundation", package: "ZIPFoundation"),
             ],
@@ -51,6 +48,18 @@ let package = Package(
             name: "FileSystemTests",
             dependencies: [
                 "FileSystem",
+            ]
+        ),
+        .target(
+            name: "Glob",
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency"),
+            ]
+        ),
+        .testTarget(
+            name: "GlobTests",
+            dependencies: [
+                "Glob",
             ]
         ),
     ]

--- a/Project.swift
+++ b/Project.swift
@@ -1,44 +1,76 @@
 import ProjectDescription
 
-let project = Project(name: "FileSystem", settings: .settings(base: ["SWIFT_STRICT_CONCURRENCY": "complete"]), targets: [
-    .target(
-        name: "FileSystem",
-        destinations: .macOS,
-        product: .staticFramework,
-        bundleId: "io.tuist.FileSystem",
-        deploymentTargets: .macOS("13.0"),
-        sources: [
-            "Sources/FileSystem/**/*.swift",
-        ],
-        dependencies: [
-            .external(name: "Glob"),
-            .external(name: "_NIOFileSystem"),
-            .external(name: "Logging"),
-            .external(name: "Path"),
-            .external(name: "ZIPFoundation"),
-        ],
-        settings: .settings(
-            base: ["GENERATE_MASTER_OBJECT_FILE": "YES", "OTHER_LDFLAGS": "$(inherited) -ObjC"],
-            configurations: [
-                .debug(name: .debug, settings: [
-                    "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING",
-                ]),
-                .release(name: .release, settings: [:]),
+let project = Project(
+    name: "FileSystem",
+    settings: .settings(base: ["SWIFT_STRICT_CONCURRENCY": "complete"]),
+    targets: [
+        .target(
+            name: "FileSystem",
+            destinations: .macOS,
+            product: .staticFramework,
+            bundleId: "io.tuist.FileSystem",
+            deploymentTargets: .macOS("13.0"),
+            sources: [
+                "Sources/FileSystem/**/*.swift",
+            ],
+            dependencies: [
+                .target(name: "Glob"),
+                .external(name: "_NIOFileSystem"),
+                .external(name: "Logging"),
+                .external(name: "Path"),
+                .external(name: "ZIPFoundation"),
+            ],
+            settings: .settings(
+                base: ["GENERATE_MASTER_OBJECT_FILE": "YES", "OTHER_LDFLAGS": "$(inherited) -ObjC"],
+                configurations: [
+                    .debug(name: .debug, settings: [
+                        "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "$(inherited) MOCKING",
+                    ]),
+                    .release(name: .release, settings: [:]),
+                ]
+            )
+        ),
+        .target(
+            name: "FileSystemTests",
+            destinations: .macOS,
+            product: .unitTests,
+            bundleId: "io.tuist.FileSystemTests",
+            deploymentTargets: .macOS("13.0"),
+            sources: [
+                "Tests/FileSystemTests/**/*.swift",
+            ],
+            dependencies: [
+                .target(name: "FileSystem"),
+            ],
+            settings: .settings(base: ["GENERATE_MASTER_OBJECT_FILE": "YES", "OTHER_LDFLAGS": "$(inherited) -ObjC"])
+        ),
+        .target(
+            name: "Glob",
+            destinations: .macOS,
+            product: .staticFramework,
+            bundleId: "io.tuist.Glob",
+            deploymentTargets: .macOS("13.0"),
+            sources: [
+                "Sources/Glob/**/*.swift",
+            ],
+            settings: .settings(base: [
+                "GENERATE_MASTER_OBJECT_FILE": "YES",
+                "OTHER_LDFLAGS": "$(inherited) -ObjC",
+                "SWIFT_STRICT_CONCURRENCY": "complete",
+            ])
+        ),
+        .target(
+            name: "GlobTests",
+            destinations: .macOS,
+            product: .unitTests,
+            bundleId: "io.tuist.FileSystemTests",
+            deploymentTargets: .macOS("13.0"),
+            sources: [
+                "Tests/GlobTests/**/*.swift",
+            ],
+            dependencies: [
+                .target(name: "Glob"),
             ]
-        )
-    ),
-    .target(
-        name: "FileSystemTests",
-        destinations: .macOS,
-        product: .unitTests,
-        bundleId: "io.tuist.FileSystemTests",
-        deploymentTargets: .macOS("13.0"),
-        sources: [
-            "Tests/FileSystemTests/**/*.swift",
-        ],
-        dependencies: [
-            .target(name: "FileSystem"),
-        ],
-        settings: .settings(base: ["GENERATE_MASTER_OBJECT_FILE": "YES", "OTHER_LDFLAGS": "$(inherited) -ObjC"])
-    ),
-])
+        ),
+    ]
+)

--- a/Sources/Glob/GlobSearch.swift
+++ b/Sources/Glob/GlobSearch.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+/// The result of a custom matcher for searching directory components
+public struct MatchResult {
+    /// When true, the url will be added to the output
+    var matches: Bool
+    /// When true, the descendents of a directory will be skipped entirely
+    ///
+    /// This has no effect if the url is not a directory.
+    var skipDescendents: Bool
+}
+
+/// Recursively search the contents of a directory, filtering by the provided patterns
+///
+/// Searching is done asynchronously, with each subdirectory searched in parallel. Results are emitted as they are found.
+///
+/// The results are returned as they are matched and do not have a consistent order to them. If you need the results sorted, wait
+/// for the entire search to complete and then sort the results.
+///
+/// - Parameters:
+///   - baseURL: The directory to search, defaults to the current working directory.
+///   - include: When provided, only includes results that match these patterns.
+///   - exclude: When provided, ignore results that match these patterns. If a directory matches an exclude pattern, none of it's
+/// descendents will be matched.
+///   - keys: An array of keys that identify the properties that you want pre-fetched for each returned url. The values for these
+/// keys are cached in the corresponding URL objects. You may specify nil for this parameter. For a list of keys you can specify,
+/// see [Common File System Resource
+/// Keys](https://developer.apple.com/documentation/corefoundation/cfurl/common_file_system_resource_keys).
+///   - skipHiddenFiles: When true, hidden files will not be returned.
+/// - Returns: An async collection of urls.
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+public func search(
+    // swiftformat:disable unusedArguments
+    directory baseURL: URL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath),
+    include: [Pattern] = [],
+    exclude: [Pattern] = [],
+    includingPropertiesForKeys keys: [URLResourceKey] = [],
+    skipHiddenFiles: Bool = true
+) -> AsyncThrowingStream<URL, any Error> {
+    AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
+        let task = Task {
+            do {
+                for include in include {
+                    let (baseURL, include) = switch include.sections.first {
+                    case let .constant(constant):
+                        if constant.hasSuffix("/") {
+                            (
+                                baseURL.appending(path: constant.dropLast()),
+                                Pattern(sections: Array(include.sections.dropFirst()), options: include.options)
+                            )
+                        } else if include.sections.count == 1 {
+                            (
+                                baseURL.appending(path: constant),
+                                Pattern(sections: Array(include.sections.dropFirst()), options: include.options)
+                            )
+                        } else if case .componentWildcard = include.sections[1] {
+                            (
+                                baseURL.appending(path: constant.components(separatedBy: "/").dropLast().joined(separator: "/")),
+                                Pattern(
+                                    sections: [.constant(constant.components(separatedBy: "/").last ?? "")] +
+                                        Array(include.sections.dropFirst()),
+                                    options: include.options
+                                )
+                            )
+                        } else {
+                            (
+                                baseURL.appending(path: constant),
+                                Pattern(sections: Array(include.sections.dropFirst()), options: include.options)
+                            )
+                        }
+                    default:
+                        (baseURL, include)
+                    }
+
+                    if include.sections.isEmpty {
+                        if FileManager.default
+                            .fileExists(atPath: baseURL.absoluteString.removingPercentEncoding ?? baseURL.absoluteString)
+                        {
+                            continuation.yield(baseURL)
+                        }
+                        continue
+                    }
+
+                    var isDirectory: ObjCBool = false
+                    guard FileManager.default.fileExists(
+                        atPath: baseURL.absoluteString.removingPercentEncoding ?? baseURL.absoluteString,
+                        isDirectory: &isDirectory
+                    ),
+                        isDirectory.boolValue
+                    else { continue }
+
+                    try await search(
+                        directory: baseURL,
+                        symbolicLinkDestination: nil,
+                        matching: { _, relativePath in
+                            guard include.match(relativePath) else {
+                                // for patterns like `**/*.swift`, parent folders won't be matched but we don't want to skip those
+                                // folder's descendents or we won't find the files that do match
+                                let skipDescendents = !include.sections.enumerated().contains(where: { index, element in
+                                    switch element {
+                                    case .pathWildcard:
+                                        return true
+                                    case .componentWildcard:
+                                        return index != include.sections.endIndex - 1
+                                    default:
+                                        return false
+                                    }
+                                })
+                                return .init(matches: false, skipDescendents: skipDescendents)
+                            }
+
+                            for pattern in exclude {
+                                if pattern.match(relativePath) {
+                                    return .init(matches: false, skipDescendents: true)
+                                }
+                            }
+
+                            return .init(matches: true, skipDescendents: false)
+                        },
+                        includingPropertiesForKeys: keys,
+                        skipHiddenFiles: skipHiddenFiles,
+                        relativePath: "",
+                        continuation: continuation
+                    )
+                }
+
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+
+        continuation.onTermination = { _ in
+            task.cancel()
+        }
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+private func search(
+    directory: URL,
+    symbolicLinkDestination: URL?,
+    matching: @escaping @Sendable (_ url: URL, _ relativePath: String) throws -> MatchResult,
+    includingPropertiesForKeys keys: [URLResourceKey],
+    skipHiddenFiles: Bool,
+    relativePath relativeDirectoryPath: String,
+    continuation: AsyncThrowingStream<URL, any Error>.Continuation
+) async throws {
+    var options: FileManager.DirectoryEnumerationOptions = [
+        .producesRelativePathURLs,
+    ]
+    if skipHiddenFiles {
+        options.insert(.skipsHiddenFiles)
+    }
+    let contents = try FileManager.default.contentsOfDirectory(
+        at: symbolicLinkDestination ?? directory,
+        includingPropertiesForKeys: keys + [.isDirectoryKey],
+        options: options
+    )
+
+    try await withThrowingTaskGroup(of: Void.self) { group in
+        for url in contents {
+            let relativePath = relativeDirectoryPath + url.lastPathComponent
+
+            let matchResult = try matching(url, relativePath)
+
+            let foundPath = directory.appending(path: url.relativePath)
+
+            if matchResult.matches {
+                continuation.yield(foundPath)
+            }
+
+            guard !matchResult.skipDescendents else { continue }
+
+            let resourceValues = try url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+            let isDirectory: Bool
+            let symbolicLinkDestination: URL?
+            if resourceValues.isDirectory == true {
+                isDirectory = true
+                symbolicLinkDestination = nil
+            } else if resourceValues.isSymbolicLink == true {
+                let resourceValues = try url.resolvingSymlinksInPath().resourceValues(forKeys: [.isDirectoryKey])
+                isDirectory = resourceValues.isDirectory == true
+                symbolicLinkDestination = url.resolvingSymlinksInPath()
+            } else {
+                isDirectory = false
+                symbolicLinkDestination = nil
+            }
+            if isDirectory {
+                group.addTask {
+                    try await search(
+                        directory: foundPath,
+                        symbolicLinkDestination: symbolicLinkDestination,
+                        matching: matching,
+                        includingPropertiesForKeys: keys,
+                        skipHiddenFiles: skipHiddenFiles,
+                        relativePath: relativePath + "/",
+                        continuation: continuation
+                    )
+                }
+            }
+        }
+
+        try await group.waitForAll()
+    }
+}

--- a/Sources/Glob/InvalidPattern.swift
+++ b/Sources/Glob/InvalidPattern.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public struct InvalidPatternError: Error {
+    /// The pattern that was being parsed
+    public var pattern: String
+    /// The location in the pattern where the error was encountered
+    public var location: String.Index
+
+    /// The reason that parsing failed
+    public var underlyingError: PatternParsingError
+}
+
+public enum PatternParsingError: Error {
+    /// The range contained a lower bound button not an upper bound (ie "[a-]")
+    case rangeNotClosed
+    /// The range was ended without any content (ie "[]")
+    case rangeIsEmpty
+    /// The range included a separator but no lower bound (ie "[-c]")
+    case rangeMissingBounds
+    /// The upper bound of a range is lower than the lower bound
+    case rangeBoundsAreOutOfOrder
+
+    /// An escape was started without an actual escaped character because the escape was at the end of the pattern
+    case invalidEscapeCharacter
+
+    /// A character class (like `[:alnum:]`) was used with an unrecognized name
+    case invalidNamedCharacterClass(String)
+
+    case patternListNotClosed
+
+    case emptyPatternList
+}

--- a/Sources/Glob/Pattern+Match.swift
+++ b/Sources/Glob/Pattern+Match.swift
@@ -1,0 +1,340 @@
+import Foundation
+
+extension Substring {
+    /// If the string has the given prefix, drop it and return the remaining string, otherwise return nil
+    func dropPrefix(_ prefix: some StringProtocol) -> Substring? {
+        if let range = range(of: prefix, options: .anchored) {
+            self[range.upperBound...]
+        } else {
+            nil
+        }
+    }
+
+    /// If the string has the given suffix, drop it and return the remaining string, otherwise return nil
+    func dropSuffix(_ suffix: some StringProtocol) -> Substring? {
+        if let range = range(of: suffix, options: [.anchored, .backwards]) {
+            self[..<range.lowerBound]
+        } else {
+            nil
+        }
+    }
+}
+
+extension Pattern {
+    /// Test if a given string matches the pattern
+    /// - Parameter name: The string to match against
+    /// - Returns: true if the string matches the pattern
+    public func match(_ name: some StringProtocol) -> Bool {
+        match(components: .init(sections), .init(name))
+    }
+
+    // recursively matches against the pattern
+    // swiftlint:disable:next function_body_length
+    private func match(
+        components: ArraySlice<Section>,
+        _ name: Substring
+    ) -> Bool {
+        if name.isEmpty {
+            if components.isEmpty || components.allSatisfy(\.matchesEmptyContent) || [
+                .pathWildcard,
+                .constant("/"),
+                .componentWildcard,
+            ] == components {
+                return true
+            } else {
+                return false
+            }
+        }
+
+        // this matches the value both from the beginning and the end, in order of what should be the most performant
+        // matching at the beginning of a string is faster than iterating over the end of a string
+        // matching constant length components is faster than wildcards
+        // matching a component level wildcard is faster than a path level wildcard because it is more likely to find a limit
+
+        // when matchLeadingDirectories is set, we can't match from the end
+
+        switch (components.first, components.last, options.matchLeadingDirectories) {
+        case let (.constant(constant), _, _):
+            if let remaining = name.dropPrefix(constant) {
+                return match(
+                    components: components.dropFirst(),
+                    remaining
+                )
+            } else {
+                return false
+            }
+        case (.singleCharacter, _, _):
+            guard name.first != options.pathSeparator else { return false }
+            if options.requiresExplicitLeadingPeriods, isAtStart(name), name.first == "." {
+                return false
+            }
+
+            return match(
+                components: components.dropFirst(),
+                name.dropFirst()
+            )
+        case let (.oneOf(ranges, isNegated: isNegated), _, _):
+            if options.requiresExplicitLeadingPeriods, isAtStart(name), name.first == "." {
+                // https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_13_01
+                // It is unspecified whether an explicit <period> in a bracket expression matching list, such as "[.abc]", can
+                // match a leading <period> in a filename.
+                // in our implimentation, it will not match
+                return false
+            }
+
+            guard let next = name.first, ranges.contains(where: { $0.contains(next) }) == !isNegated else { return false }
+            return match(
+                components: components.dropFirst(),
+                name.dropFirst()
+            )
+        case let (_, .constant(constant), false):
+            if let remaining = name.dropSuffix(constant) {
+                return match(
+                    components: components.dropLast(),
+                    remaining
+                )
+            } else if [.pathWildcard, .constant("/")] == components.suffix(2) {
+                return match(
+                    components: components.dropLast(2),
+                    name
+                )
+            } else {
+                switch components.last {
+                case let .constant(constant):
+                    if constant.hasSuffix("/") {
+                        return match(
+                            components: components.dropLast() + [.constant(String(constant.dropLast(1)))],
+                            name
+                        )
+                    } else if constant.hasPrefix("/"), components.first == .pathWildcard {
+                        return match(
+                            components: [.constant(String(constant.dropFirst()))],
+                            name
+                        )
+                    } else {
+                        return false
+                    }
+                default:
+                    return false
+                }
+            }
+        case (_, .singleCharacter, false):
+            guard name.last != options.pathSeparator else { return false }
+            return match(
+                components: components.dropLast(),
+                name.dropLast()
+            )
+        case let (_, .oneOf(ranges, isNegated: isNegated), false):
+            guard let next = name.last, ranges.contains(where: { $0.contains(next) }) == !isNegated else { return false }
+            return match(
+                components: components.dropLast(),
+                name.dropLast()
+            )
+        case (.componentWildcard, _, _):
+            if options.requiresExplicitLeadingPeriods, isAtStart(name), name.first == "." {
+                return false
+            }
+
+            if components.count == 1 {
+                if let pathSeparator = options.pathSeparator, !options.matchLeadingDirectories {
+                    // the last component is a component level wildcard, which matches anything except for the path separator
+                    return !name.contains(pathSeparator)
+                } else {
+                    // no special treatment for path separators
+                    return true
+                }
+            }
+
+            if match(components: components.dropFirst(), name) {
+                return true
+            } else {
+                return match(components: components, name.dropFirst())
+            }
+        case (_, .componentWildcard, false):
+            if match(components: components.dropLast(), name) {
+                return true
+            } else {
+                return match(components: components, name.dropLast())
+            }
+        case (.pathWildcard, _, _):
+            if components.count == 1 {
+                // the last component is a path level wildcard, which matches anything
+                return true
+            }
+
+            if match(components: components.dropFirst(), name) {
+                return true
+            } else {
+                return match(components: components, name.dropFirst())
+            }
+        case let (.patternList(style, subSections), _, _):
+            let remaining = matchPatternListPrefix(
+                components: components,
+                name,
+                style: style,
+                subSections: subSections
+            )
+
+            return remaining?.isEmpty == true
+        case (.none, _, _):
+            if options.matchLeadingDirectories, name.first == options.pathSeparator {
+                return true
+            }
+
+            return name.isEmpty
+        }
+    }
+
+    /// Matches the beginning of the string and returns the rest. If a match cannot be made, returns nil.
+    private func matchPrefix(
+        components: ArraySlice<Section>,
+        _ name: Substring
+    ) -> Substring? {
+        if name.isEmpty {
+            if components.isEmpty || components.allSatisfy(\.matchesEmptyContent) {
+                return name.dropAll()
+            } else {
+                return nil
+            }
+        }
+
+        switch components.first {
+        case let .constant(constant):
+            if let remaining = name.dropPrefix(constant) {
+                return matchPrefix(
+                    components: components.dropFirst(),
+                    remaining
+                )
+            } else {
+                return nil
+            }
+        case .singleCharacter:
+            guard name.first != options.pathSeparator else { return nil }
+            if options.requiresExplicitLeadingPeriods, isAtStart(name) {
+                return nil
+            }
+
+            return matchPrefix(
+                components: components.dropFirst(),
+                name.dropFirst()
+            )
+        case let .oneOf(ranges, isNegated: isNegated):
+            if options.requiresExplicitLeadingPeriods, isAtStart(name) {
+                // https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_13_01
+                // It is unspecified whether an explicit <period> in a bracket expression matching list, such as "[.abc]", can
+                // match a leading <period> in a filename.
+                // in our implimentation, it will not match
+                return nil
+            }
+
+            guard let next = name.first, ranges.contains(where: { $0.contains(next) }) == !isNegated else { return nil }
+            return matchPrefix(
+                components: components.dropFirst(),
+                name.dropFirst()
+            )
+        case .componentWildcard:
+            if options.requiresExplicitLeadingPeriods, isAtStart(name) {
+                return nil
+            }
+
+            if components.count == 1 {
+                if let pathSeparator = options.pathSeparator, !options.matchLeadingDirectories {
+                    // the last component is a component level wildcard, which matches anything except for the path separator
+                    if let index = name.firstIndex(of: pathSeparator) {
+                        return name.suffix(from: index)
+                    } else {
+                        return name.dropAll()
+                    }
+                } else {
+                    // no special treatment for path separators
+                    return name.dropAll()
+                }
+            }
+
+            if let remaining = matchPrefix(components: components.dropFirst(), name) {
+                return remaining
+            } else {
+                return matchPrefix(components: components, name.dropFirst())
+            }
+        case .pathWildcard:
+            if components.count == 1 {
+                // the last component is a path level wildcard, which matches anything
+                return name.dropAll()
+            }
+
+            if let remaining = matchPrefix(components: components.dropFirst(), name) {
+                return remaining
+            } else {
+                return matchPrefix(components: components, name.dropFirst())
+            }
+        case let .patternList(style, subSections):
+            return matchPatternListPrefix(
+                components: components,
+                name,
+                style: style,
+                subSections: subSections
+            )
+        case .none:
+            return name
+        }
+    }
+
+    private func matchPatternListPrefix(
+        components: ArraySlice<Section>,
+        _ name: Substring,
+        style: Section.PatternListStyle,
+        subSections: [[Section]]
+    ) -> Substring? {
+        for sectionsOption in subSections {
+            if let remaining = matchPrefix(
+                components: ArraySlice(sectionsOption + components.dropFirst()),
+                name
+            ) {
+                // stop infinite recursion
+                guard remaining != name else { return remaining }
+
+                switch style {
+                case .negated:
+                    return nil
+                case .oneOrMore, .zeroOrMore:
+                    // switch to zeroOrMore since we've already fulfilled the "one" requirement
+                    return matchPrefix(
+                        components: [.patternList(.zeroOrMore, subSections)] + components.dropFirst(),
+                        remaining
+                    )
+                case .one, .zeroOrOne:
+                    // already matched "one", can't match any more
+                    return remaining
+                }
+            }
+        }
+
+        switch style {
+        case .negated:
+            return matchPrefix(components: [.pathWildcard] + components.dropFirst(), name)
+        case .zeroOrMore, .zeroOrOne:
+            return matchPrefix(components: components.dropFirst(), name)
+        case .one, .oneOrMore:
+            return nil
+        }
+    }
+
+    private func isAtStart(_ name: Substring) -> Bool {
+        name.startIndex == name.base.startIndex || name.previous() == options.pathSeparator
+    }
+}
+
+extension Substring {
+    /// Returns the character just before the substring starts
+    fileprivate func previous() -> Character? {
+        guard startIndex > base.startIndex else { return nil }
+        let index = base.index(before: startIndex)
+
+        return base[index]
+    }
+
+    /// returns an empty substring preserving endIndex
+    fileprivate func dropAll() -> Substring {
+        suffix(0)
+    }
+}

--- a/Sources/Glob/Pattern+Options.swift
+++ b/Sources/Glob/Pattern+Options.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+extension Pattern {
+    /// Options to control how patterns are parsed and matched
+    public struct Options: Equatable, Sendable {
+        /// If a double star/asterisk causes the pattern to match path separators.
+        ///
+        /// If `pathSeparator` is `nil` this has no effect.
+        public var supportsPathLevelWildcards: Bool = true
+
+        /// How empty ranges (`[]`) are treated
+        public enum EmptyRangeBehavior: Sendable {
+            /// Treat an empty range as matching nothing, equivalent to nothing at all
+            case allow
+            /// Throw an error when an empty range is used
+            case error
+            /// When a range starts with a closing range character, treat the closing bracket as a character and continue the
+            /// range
+            case treatClosingBracketAsCharacter
+        }
+
+        /// How are empty ranges handled.
+        public var emptyRangeBehavior: EmptyRangeBehavior = .error
+
+        /// If the pattern supports escaping control characters with '\'
+        ///
+        /// When true, a backslash character ( '\' ) in pattern followed by any other character shall match that second character
+        /// in string. In particular, "\\" shall match a backslash in string. Otherwise a backslash character shall be treated as
+        /// an ordinary character.
+        public var supportsEscapedCharacters: Bool = true
+
+        /// Allows the `-` character to be included in a character class if it is the first or last character (ie `[-abc]` or
+        /// `[abc-]`)
+        public var supportsRangeSeparatorAtBeginningAndEnd: Bool = true
+
+        /// If a period in the name is at the beginning of a component, don't match using wildcards.
+        ///
+        /// Treat the `.` character specially if it appears at the beginning of string. If this flag is set, wildcard constructs
+        /// in pattern cannot match `.` as the first character of string. If you set both this and `pathSeparator`, then the
+        /// special treatment applies to `.` following `pathSeparator` as well as to `.` at the beginning of string.
+        ///
+        /// Equivalent to `FNM_PERIOD`.
+        public var requiresExplicitLeadingPeriods: Bool = true
+
+        /// If a pattern should match if it matches a parent directory, as defined by `pathSeparator`.
+        ///
+        /// Ignore a trailing sequence of characters starting with a `/` in string; that is to say, test whether string starts
+        /// with a directory name that pattern matches. If this flag is set, either `foo*` or `foobar` as a pattern would match
+        /// the string `foobar/frobozz`. Equivalent to `FNM_LEADING_DIR`.`
+        ///
+        /// If `pathSeparator` is `nil` this has no effect.
+        public var matchLeadingDirectories: Bool = false
+
+        /// Recognize beside the normal patterns also the extended patterns introduced in `ksh`. Equivalent to `FNM_EXTMATCH`.
+        ///
+        /// The patterns are written in the form explained in the following table where pattern-list is a | separated list of
+        /// patterns.
+        ///
+        /// - ?(pattern-list)
+        /// 	The pattern matches if zero or one occurences of any of the patterns in the pattern-list allow matching the input
+        /// string.
+        /// - *(pattern-list)
+        /// 	The pattern matches if zero or more occurences of any of the patterns in the pattern-list allow matching the input
+        /// string.
+        /// - +(pattern-list)
+        /// 	The pattern matches if one or more occurences of any of the patterns in the pattern-list allow matching the input
+        /// string.
+        /// - @(pattern-list)
+        /// 	The pattern matches if exactly one occurence of any of the patterns in the pattern-list allows matching the input
+        /// string.
+        /// - !(pattern-list)
+        /// 	The pattern matches if the input string cannot be matched with any of the patterns in the pattern-list.
+        public var supportsPatternLists: Bool = true
+
+        /// The character used to invert a character class.
+        public enum RangeNegationCharacter: Equatable, Sendable {
+            /// Use the `!` character to denote an inverse character class.
+            case exclamationMark
+            /// Use the `^` character to denote an inverse character class.
+            case caret
+        }
+
+        /// The character used to specify when a range matches characters that aren't in the range.
+        public var rangeNegationCharacter: RangeNegationCharacter = .exclamationMark
+
+        /// The path separator to use in matching
+        ///
+        /// If this is `nil`, path separators have no special meaning. This is equivalent to excluding `FNM_PATHNAME` in
+        /// `fnmatch`.
+        ///
+        /// Defaults to "/" regardless of operating system.
+        public var pathSeparator: Character? = "/"
+
+        /// Default options for parsing and matching patterns.
+        public static let `default`: Self = .init(
+            supportsPathLevelWildcards: true,
+            emptyRangeBehavior: .error
+        )
+
+        /// Attempts to match the behavior of [`filepath.Match` in go](https://pkg.go.dev/path/filepath#Match).
+        public static let go: Self = Options(
+            supportsPathLevelWildcards: false,
+            emptyRangeBehavior: .error,
+            supportsRangeSeparatorAtBeginningAndEnd: false,
+            rangeNegationCharacter: .caret
+        )
+
+        /// Attempts to match the behavior of [POSIX glob](https://man7.org/linux/man-pages/man7/glob.7.html).
+        /// - Returns: Options to use to create a Pattern.
+        public static func posix() -> Self {
+            Options(
+                supportsPathLevelWildcards: false,
+                emptyRangeBehavior: .allow,
+                requiresExplicitLeadingPeriods: true
+            )
+        }
+    }
+}

--- a/Sources/Glob/Pattern+Parser.swift
+++ b/Sources/Glob/Pattern+Parser.swift
@@ -1,0 +1,337 @@
+extension Pattern {
+    struct Parser {
+        private var pattern: Substring
+        let options: Options
+
+        init(pattern: some StringProtocol, options: Options) {
+            self.pattern = Substring(pattern)
+            self.options = options
+        }
+
+        enum Token: Equatable {
+            case character(Character)
+            case leftSquareBracket // [
+            case rightSquareBracket // ]
+            case questionMark // ?
+            case dash // -
+            case asterisk // *
+            case colon // :
+            case leftParen // (
+            case rightParen // )
+            case verticalLine // |
+            case at // @
+            case plus // +
+            case exclamationMark // !
+            case caret // ^
+
+            init(_ character: Character) {
+                switch character {
+                case "]":
+                    self = .rightSquareBracket
+                case "[":
+                    self = .leftSquareBracket
+                case "?":
+                    self = .questionMark
+                case "-":
+                    self = .dash
+                case "*":
+                    self = .asterisk
+                case ":":
+                    self = .colon
+                case "(":
+                    self = .leftParen
+                case ")":
+                    self = .rightParen
+                case "|":
+                    self = .verticalLine
+                case "@":
+                    self = .at
+                case "+":
+                    self = .plus
+                case "!":
+                    self = .exclamationMark
+                case "^":
+                    self = .caret
+                default:
+                    self = .character(character)
+                }
+            }
+
+            var character: Character {
+                switch self {
+                case let .character(character):
+                    character
+                case .leftSquareBracket:
+                    "["
+                case .rightSquareBracket:
+                    "]"
+                case .questionMark:
+                    "?"
+                case .dash:
+                    "-"
+                case .asterisk:
+                    "*"
+                case .colon:
+                    ":"
+                case .leftParen:
+                    "("
+                case .rightParen:
+                    ")"
+                case .verticalLine:
+                    "|"
+                case .at:
+                    "@"
+                case .plus:
+                    "+"
+                case .exclamationMark:
+                    "!"
+                case .caret:
+                    "^"
+                }
+            }
+        }
+
+        mutating func pop(_ condition: (Token) -> Bool = { _ in true }) throws -> Token? {
+            if let next = pattern.first {
+                let updatedPattern = pattern.dropFirst()
+
+                if options.supportsEscapedCharacters, next == .escape {
+                    guard let escaped = updatedPattern.first else { throw PatternParsingError.invalidEscapeCharacter }
+
+                    guard condition(.character(escaped)) else { return nil }
+
+                    pattern = updatedPattern.dropFirst()
+                    return .character(escaped)
+                } else {
+                    let token = Token(next)
+
+                    guard condition(token) else { return nil }
+
+                    pattern = updatedPattern
+                    return token
+                }
+            }
+
+            return nil
+        }
+
+        mutating func pop(_ token: Token) throws -> Bool {
+            try pop { $0 == token } != nil
+        }
+
+        mutating func parse() throws -> Pattern {
+            do {
+                let sections = try parseSections()
+
+                return Pattern(sections: sections, options: options)
+            } catch let error as PatternParsingError {
+                // add information about where the error was encountered by including the original pattern and our current
+                // location
+                throw InvalidPatternError(
+                    pattern: pattern.base,
+                    location: pattern.startIndex,
+                    underlyingError: error
+                )
+            }
+        }
+
+        // swiftlint:disable:next function_body_length
+        private mutating func parseSections(delimeters: some Collection<Token> = EmptyCollection()) throws -> [Section] {
+            var sections: [Section] = []
+
+            while let next = try pop({ !delimeters.contains($0) }) {
+                switch next {
+                case .asterisk:
+                    if options.supportsPatternLists, let sectionList = try parsePatternList() {
+                        sections.append(.patternList(.zeroOrMore, sectionList))
+                    } else if sections.last == .componentWildcard {
+                        if options.supportsPathLevelWildcards {
+                            sections[sections.endIndex - 1] = .pathWildcard
+                        } else {
+                            break // ignore repeated wildcards
+                        }
+                    } else if sections.last == .pathWildcard {
+                        break // ignore repeated wildcards
+                    } else {
+                        sections.append(.componentWildcard)
+                    }
+                case .questionMark:
+                    if options.supportsPatternLists, let sectionList = try parsePatternList() {
+                        sections.append(.patternList(.zeroOrOne, sectionList))
+                    } else {
+                        sections.append(.singleCharacter)
+                    }
+                case .at:
+                    if options.supportsPatternLists, let sectionsList = try parsePatternList() {
+                        sections.append(.patternList(.one, sectionsList))
+                    } else {
+                        sections.append(constant: next.character)
+                    }
+                case .plus:
+                    if options.supportsPatternLists, let sectionsList = try parsePatternList() {
+                        sections.append(.patternList(.oneOrMore, sectionsList))
+                    } else {
+                        sections.append(constant: next.character)
+                    }
+                case .exclamationMark:
+                    if options.supportsPatternLists, let sectionsList = try parsePatternList() {
+                        sections.append(.patternList(.negated, sectionsList))
+                    } else {
+                        sections.append(constant: next.character)
+                    }
+                case .leftSquareBracket:
+                    let negated: Bool
+                    if try pop(options.rangeNegationCharacter.token) {
+                        negated = true
+                    } else {
+                        negated = false
+                    }
+
+                    var ranges: [CharacterClass] = []
+
+                    if options.emptyRangeBehavior == .treatClosingBracketAsCharacter, try pop(.rightSquareBracket) {
+                        // https://man7.org/linux/man-pages/man7/glob.7.html
+                        // The string enclosed by the brackets cannot be empty; therefore ']' can be allowed between the brackets,
+                        // provided that it is the first character.
+                        ranges.append(.character("]"))
+                    }
+
+                    loop: while true {
+                        guard let next = try pop() else {
+                            throw PatternParsingError.rangeNotClosed
+                        }
+
+                        switch next {
+                        case .rightSquareBracket:
+                            break loop
+                        case .leftSquareBracket:
+                            if try pop(.colon) {
+                                // Named character classes
+                                guard let endIndex = pattern.firstIndex(of: ":") else { throw PatternParsingError.rangeNotClosed }
+
+                                let name = pattern.prefix(upTo: endIndex)
+
+                                if let name = CharacterClass.Name(rawValue: String(name)) {
+                                    ranges.append(.named(name))
+                                    pattern = pattern[endIndex...].dropFirst()
+
+                                    if try !pop(.rightSquareBracket) {
+                                        throw PatternParsingError.rangeNotClosed
+                                    }
+                                } else {
+                                    throw PatternParsingError.invalidNamedCharacterClass(String(name))
+                                }
+                            } else {
+                                ranges.append(.character("["))
+                            }
+                        case .dash:
+                            if !options.supportsRangeSeparatorAtBeginningAndEnd {
+                                throw PatternParsingError.rangeMissingBounds
+                            }
+
+                            // https://man7.org/linux/man-pages/man7/glob.7.html
+                            // One may include '-' in its literal meaning by making it the first or last character between the
+                            // brackets.
+                            ranges.append(.character("-"))
+                        default:
+                            if try pop(.dash) {
+                                if try pop(.rightSquareBracket) {
+                                    if !options.supportsRangeSeparatorAtBeginningAndEnd {
+                                        throw PatternParsingError.rangeNotClosed
+                                    }
+
+                                    // `-` is the last character in the group, treat it as a character
+                                    // https://man7.org/linux/man-pages/man7/glob.7.html
+                                    // One may include '-' in its literal meaning by making it the first or last character between
+                                    // the brackets.
+                                    ranges.append(.character(next.character))
+                                    ranges.append(.character("-"))
+
+                                    break loop
+                                } else {
+                                    // this is a range like a-z, find the upper limit of the range
+                                    guard let upper = try pop()
+                                    else { throw PatternParsingError.rangeNotClosed }
+
+                                    guard next.character <= upper.character
+                                    else { throw PatternParsingError.rangeBoundsAreOutOfOrder }
+                                    ranges.append(.range(next.character ... upper.character))
+                                }
+                            } else {
+                                ranges.append(.character(next.character))
+                            }
+                        }
+                    }
+
+                    guard !ranges.isEmpty else {
+                        if options.emptyRangeBehavior == .error {
+                            throw PatternParsingError.rangeIsEmpty
+                        } else {
+                            break
+                        }
+                    }
+
+                    sections.append(.oneOf(ranges, isNegated: negated))
+                case let .character(character):
+                    sections.append(constant: character)
+                case .rightSquareBracket, .dash, .colon, .leftParen, .rightParen, .verticalLine, .caret:
+                    sections.append(constant: next.character)
+                }
+            }
+
+            return sections
+        }
+
+        /// Parses a pattern list like `(abc|xyz)`
+        mutating func parsePatternList() throws -> [[Section]]? {
+            if options.supportsPatternLists, try pop(.leftParen) {
+                // start of pattern list
+                var sectionsList: [[Section]] = []
+
+                loop: while !pattern.isEmpty {
+                    let subSections = try parseSections(delimeters: [.verticalLine, .rightParen])
+
+                    sectionsList.append(subSections)
+
+                    switch try pop() {
+                    case .verticalLine:
+                        continue
+                    case .rightParen:
+                        break loop
+                    default:
+                        throw PatternParsingError.patternListNotClosed
+                    }
+                }
+
+                guard !sectionsList.isEmpty else {
+                    throw PatternParsingError.emptyPatternList
+                }
+
+                return sectionsList
+            } else {
+                return nil
+            }
+        }
+    }
+}
+
+extension [Pattern.Section] {
+    fileprivate mutating func append(constant character: Character) {
+        if case let .constant(value) = last {
+            self[endIndex - 1] = .constant(value + String(character))
+        } else {
+            append(.constant(String(character)))
+        }
+    }
+}
+
+extension Pattern.Options.RangeNegationCharacter {
+    var token: Pattern.Parser.Token {
+        switch self {
+        case .exclamationMark:
+            .exclamationMark
+        case .caret:
+            .caret
+        }
+    }
+}

--- a/Sources/Glob/Pattern.swift
+++ b/Sources/Glob/Pattern.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+extension Character {
+    static let escape: Character = #"\"#
+}
+
+/// A glob pattern that can be matched against string content.
+public struct Pattern: Equatable, Sendable {
+    public enum Section: Equatable, Sendable {
+        /// A wildcard that matches any 0 or more characters except for the path separator ("/" by default)
+        case componentWildcard
+        /// A wildcard that matches any 0 or more characters
+        case pathWildcard
+
+        /// Matches an exact string
+        case constant(String)
+        /// Matches any single character
+        case singleCharacter
+        /// Matches a single character in any of the given ranges
+        ///
+        /// A range may be a single character (ie "a"..."a"). For instance the pattern [abc] will create 3 ranges that are each a
+        /// single character.
+        case oneOf([CharacterClass], isNegated: Bool)
+
+        public enum PatternListStyle: Equatable, Sendable {
+            case zeroOrOne
+            case zeroOrMore
+            case oneOrMore
+            case one
+            case negated
+
+            var allowsZero: Bool {
+                switch self {
+                case .zeroOrOne, .zeroOrMore, .negated:
+                    true
+                case .oneOrMore, .one:
+                    false
+                }
+            }
+
+            var allowsMultiple: Bool {
+                switch self {
+                case .oneOrMore, .zeroOrMore:
+                    true
+                case .zeroOrOne, .one, .negated:
+                    false
+                }
+            }
+        }
+
+        case patternList(_ style: PatternListStyle, _ sections: [[Section]])
+
+        /// If the section can match a variable length of characters
+        ///
+        /// When false, the section represents a fixed length match.
+        public var matchesEmptyContent: Bool {
+            switch self {
+            case .constant, .singleCharacter, .oneOf:
+                false
+            case .componentWildcard, .pathWildcard:
+                true
+            case let .patternList(style, subSections):
+                switch style {
+                case .negated, .zeroOrOne, .zeroOrMore:
+                    true
+                case .one, .oneOrMore:
+                    subSections.contains(where: { subSection in
+                        subSection.allSatisfy { section in
+                            section.matchesEmptyContent
+                        }
+                    })
+                }
+            }
+        }
+    }
+
+    public enum CharacterClass: Equatable, Sendable {
+        case range(ClosedRange<Character>)
+
+        public enum Name: String, Equatable, Sendable {
+            // https://man7.org/linux/man-pages/man7/glob.7.html
+            // https://www.domaintools.com/resources/user-guides/dnsdb-glob-reference-guide/
+
+            /// Alphanumeric characters 0-9, A-Z, and a-z
+            case alphaNumeric = "alnum"
+            /// Alphabetic characters A-Z, a-z
+            case alpha
+            /// Blank characters (space and tab)
+            case blank
+            /// Control characters
+            case control = "cntrl"
+            /// Decimal digits 0-9
+            case numeric = "digit"
+            /// Any printable character other than space.
+            case graph
+            /// Lower case alphabetic characters a-z
+            case lower
+            /// Any printable character
+            case printable = "print"
+            /// Printable characters other than space and `alphaNumeric`
+            case punctuation = "punct"
+            ///  Any whitespace character
+            case space
+            /// Upper case alphabetic characters A-Z
+            case upper
+            /// Hexadecimal digits 0-9, a-f, A-F
+            case hexadecimalDigit = "xdigit"
+
+            public func contains(_ character: Character) -> Bool {
+                switch self {
+                case .alphaNumeric:
+                    character.isLetter || character.isNumber
+                case .alpha:
+                    character.isLetter
+                case .blank:
+                    character.isWhitespace
+                case .control:
+                    character.unicodeScalars
+                        .allSatisfy { $0.properties.generalCategory == .control }
+                case .numeric:
+                    character.isNumber
+                case .graph:
+                    character != " " && character.unicodeScalars
+                        .allSatisfy(\.properties.generalCategory.isPrintable)
+                case .lower:
+                    character.isLowercase
+                case .printable:
+                    character.unicodeScalars
+                        .allSatisfy(\.properties.generalCategory.isPrintable)
+                case .punctuation:
+                    character.isPunctuation
+                case .space:
+                    character.isWhitespace
+                case .upper:
+                    character.isUppercase
+                case .hexadecimalDigit:
+                    character.isHexDigit
+                }
+            }
+        }
+
+        case named(Name)
+
+        static func character(_ character: Character) -> Self {
+            .range(character ... character)
+        }
+
+        public func contains(_ character: Character) -> Bool {
+            switch self {
+            case let .range(closedRange):
+                closedRange.contains(character)
+            case let .named(name):
+                name.contains(character)
+            }
+        }
+    }
+
+    /// The individual parts of the pattern to match against
+    public var sections: [Section]
+    /// Options used for parsing and matching
+    public var options: Options
+
+    init(sections: [Section], options: Options) {
+        self.sections = sections
+        self.options = options
+    }
+
+    /// Parses a pattern string into a reusable pattern
+    public init(
+        _ pattern: some StringProtocol,
+        options: Options = .default
+    ) throws {
+        var parser = Parser(pattern: pattern, options: options)
+        self = try parser.parse()
+    }
+}

--- a/Sources/Glob/Unicode.GeneralCategory+Helpers.swift
+++ b/Sources/Glob/Unicode.GeneralCategory+Helpers.swift
@@ -1,0 +1,17 @@
+extension Unicode.GeneralCategory {
+    var isPrintable: Bool {
+        switch self {
+        case .uppercaseLetter, .lowercaseLetter, .titlecaseLetter, .modifierLetter, .otherLetter, .nonspacingMark, .spacingMark,
+             .enclosingMark, .decimalNumber, .letterNumber, .otherNumber, .connectorPunctuation, .dashPunctuation,
+             .openPunctuation,
+             .closePunctuation, .initialPunctuation, .finalPunctuation, .otherPunctuation, .spaceSeparator, .lineSeparator,
+             .paragraphSeparator, .surrogate, .privateUse, .unassigned, .mathSymbol, .currencySymbol, .modifierSymbol,
+             .otherSymbol:
+            true
+        case .control, .format:
+            false
+        @unknown default:
+            true
+        }
+    }
+}

--- a/Tests/GlobTests/PatternTests.swift
+++ b/Tests/GlobTests/PatternTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+
+@testable import Glob
+
+final class PatternTests: XCTestCase {
+    func test_pathWildcard_matchesSingleNestedFolders() throws {
+        try XCTAssertMatches("Target/AutoMockable.generated.swift", pattern: "**/*.generated.swift")
+    }
+
+    func test_pathWildcard_with_constant_component() throws {
+        try XCTAssertMatches("file.swift", pattern: "**/file.swift")
+    }
+
+    func test_pathWildcard_matchesDirectFile() throws {
+        try XCTAssertMatches("AutoMockable.generated.swift", pattern: "**/*.generated.swift")
+    }
+
+    func test_pathWildcard_does_not_match() throws {
+        try XCTAssertDoesNotMatch("AutoMockable.non-generated.swift", pattern: "**/*.generated.swift")
+    }
+
+    func test_double_pathWildcard_matchesDirectFileInNestedDirectory() throws {
+        try XCTAssertMatches("Target/Pivot/AutoMockable.generated.swift", pattern: "**/Pivot/**/*.generated.swift")
+    }
+
+    func test_double_pathWildcard_does_not_match_when_pivot_does_not_match() throws {
+        try XCTAssertDoesNotMatch(
+            "Target/NonMatchingPivot/AutoMockable.generated.swift",
+            pattern: "**/Pivot/**/*.generated.swift"
+        )
+    }
+
+    func test_double_pathWildcard_with_prefix_constants_matchesDirectFileInNestedDirectory() throws {
+        try XCTAssertMatches("Target/Extra/Pivot/AutoMockable.generated.swift", pattern: "Target/**/Pivot/**/*.generated.swift")
+    }
+
+    func test_pathWildcard_matchesMultipleNestedFolders() throws {
+        try XCTAssertMatches("Target/Generated/AutoMockable.generated.swift", pattern: "**/*.generated.swift")
+    }
+
+    func test_componentWildcard_matchesNonNestedFiles() throws {
+        try XCTAssertMatches("AutoMockable.generated.swift", pattern: "*.generated.swift")
+    }
+
+    func test_componentWildcard_doesNotMatchNestedPaths() throws {
+        try XCTAssertDoesNotMatch("Target/AutoMockable.generated.swift", pattern: "*.generated.swift")
+    }
+
+    func test_multipleWildcards_matchesWithMultipleConstants() throws {
+        // this can be tricky for some implementations because as they are parsing the first wildcard,
+        // it will see a match and move on and the remaining pattern and content will not match
+        try XCTAssertMatches("Target/AutoMockable/Sources/AutoMockable.generated.swift", pattern: "**/AutoMockable*.swift")
+    }
+
+    func test_pathWildcard_pathComponentsOnly_doesNotMatchPath() throws {
+        var options = Pattern.Options.default
+        options.supportsPathLevelWildcards = false
+        try XCTAssertDoesNotMatch("Target/Other/.build", pattern: "**/.build", options: options)
+    }
+
+    func test_componentWildcard_pathComponentsOnly_doesMatchSingleComponent() throws {
+        var options = Pattern.Options.default
+        options.supportsPathLevelWildcards = false
+        try XCTAssertMatches("Target/.build", pattern: "*/.build", options: options)
+    }
+
+    func test_constant() throws {
+        try XCTAssertMatches("abc", pattern: "abc")
+    }
+
+    func test_ranges() throws {
+        try XCTAssertMatches("b", pattern: "[a-c]")
+        try XCTAssertMatches("B", pattern: "[A-C]")
+        try XCTAssertDoesNotMatch("n", pattern: "[a-c]")
+    }
+
+    func test_multipleRanges() throws {
+        try XCTAssertMatches("b", pattern: "[a-cA-C]")
+        try XCTAssertMatches("B", pattern: "[a-cA-C]")
+        try XCTAssertDoesNotMatch("n", pattern: "[a-cA-C]")
+        try XCTAssertDoesNotMatch("N", pattern: "[a-cA-C]")
+        try XCTAssertDoesNotMatch("n", pattern: "[a-cA-Z]")
+        try XCTAssertMatches("N", pattern: "[a-cA-Z]")
+    }
+
+    func test_negateRange() throws {
+        try XCTAssertDoesNotMatch("abc", pattern: "ab[^c]", options: .go)
+    }
+
+    func test_singleCharacter_doesNotMatchSeparator() throws {
+        try XCTAssertDoesNotMatch("a/b", pattern: "a?b")
+    }
+
+    func test_namedCharacterClasses_alpha() throws {
+        try XCTAssertMatches("b", pattern: "[[:alpha:]]")
+        try XCTAssertMatches("B", pattern: "[[:alpha:]]")
+        try XCTAssertMatches("ē", pattern: "[[:alpha:]]")
+        try XCTAssertMatches("ž", pattern: "[[:alpha:]]")
+        try XCTAssertDoesNotMatch("9", pattern: "[[:alpha:]]")
+        try XCTAssertDoesNotMatch("&", pattern: "[[:alpha:]]")
+    }
+}

--- a/Tests/GlobTests/TestHelpers/XCTAssertMatches.swift
+++ b/Tests/GlobTests/TestHelpers/XCTAssertMatches.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+@testable import Glob
+
+func XCTAssertMatches(
+    _ value: String,
+    pattern: String,
+    options: Glob.Pattern.Options = .default,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws {
+    try XCTAssertTrue(
+        Pattern(pattern, options: options).match(value),
+        "\(value) did not match pattern \(pattern) with options \(options)",
+        file: file,
+        line: line
+    )
+}
+
+func XCTAssertDoesNotMatch(
+    _ value: String,
+    pattern: String,
+    options: Glob.Pattern.Options = .default,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws {
+    try XCTAssertFalse(
+        Pattern(pattern, options: options).match(value),
+        "'\(value)' matched pattern '\(pattern)' with options \(options)",
+        file: file,
+        line: line
+    )
+}

--- a/Tests/GlobTests/TestHelpers/XCTExpectFailure.swift
+++ b/Tests/GlobTests/TestHelpers/XCTExpectFailure.swift
@@ -1,0 +1,5 @@
+// XCTExpectFailure is only available on Apple platforms
+// https://github.com/apple/swift-corelibs-xctest/issues/438
+#if !os(macOS) && !os(iOS) && !os(watchOS) && !os(tvOS)
+    func XCTExpectFailure(_: () throws -> Void) rethrows {}
+#endif


### PR DESCRIPTION
We have been more and more diverging from the original [swift-glob](https://github.com/davbeck/swift-glob) library to align with the behavior we need in `tuist/tuist`. That work has been happening in our fork: https://github.com/tuist/swift-glob

Fixing issues in our `swift-glob` meant having to update `swift-glob`, `FileSystem`, and only then update the `FileSystem` in `tuist/tuist`. To simplify the setup, we're importing the necessary subset of `swift-glob` and we're taking full ownership of that part of the library.