### PR TITLE
fix: ignore .DS_Store results when globbing

### DIFF
--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -608,6 +608,9 @@ public struct FileSystem: FileSysteming, Sendable {
             directory: URL(string: directory.pathString)!,
             include: try include
                 .map { try Pattern($0) },
+            exclude: [
+                try Pattern("**/.DS_Store"),
+            ],
             skipHiddenFiles: false
         )
         .map {


### PR DESCRIPTION
Related: https://github.com/tuist/tuist/issues/6991

`.DS_Store` should be excluded by default.