### PR TITLE
fix: use FileManager for file and directory removal to fix performance issues

### DIFF
--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -78,12 +78,6 @@ public protocol FileSysteming {
     /// - Parameter path: The path to the file or directory to remove.
     func remove(_ path: AbsolutePath) async throws
 
-    /// It removes the file or directory at the given path.
-    /// - Parameters:
-    ///   - path: The path to the file or directory to remove.
-    ///   - recursively: When removing a directory, it removes the sub-directories recursively.
-    func remove(_ path: AbsolutePath, recursively: Bool) async throws
-
     /// Creates a temporary directory and returns its path.
     /// - Parameter prefix: Prefix for the randomly-generated directory name.
     /// - Returns: The path to the directory.
@@ -300,17 +294,12 @@ public struct FileSystem: FileSysteming, Sendable {
         }
     }
 
-    public func remove(_ path: Path.AbsolutePath) async throws {
-        try await remove(path, recursively: true)
-    }
-
-    public func remove(_ path: AbsolutePath, recursively: Bool) async throws {
-        if recursively {
-            logger?.debug("Removing the directory at path recursively: \(path.pathString).")
-        } else {
-            logger?.debug("Removing the file or directory at path: \(path.pathString).")
+    public func remove(_ path: AbsolutePath) async throws {
+        logger?.debug("Removing the file or directory at path: \(path.pathString).")
+        try await Task {
+            try FileManager.default.removeItem(atPath: path.pathString)
         }
-        try await NIOFileSystem.FileSystem.shared.removeItem(at: .init(path.pathString), recursively: recursively)
+        .value
     }
 
     public func makeTemporaryDirectory(prefix: String) async throws -> AbsolutePath {

--- a/Tests/FileSystemTests/FileSystemTests.swift
+++ b/Tests/FileSystemTests/FileSystemTests.swift
@@ -886,4 +886,41 @@ final class FileSystemTests: XCTestCase, @unchecked Sendable {
             XCTAssertEqual(got, [fourthSourceFile, thirdSourceFile])
         }
     }
+
+    func test_remove_file() async throws {
+        try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+            // Given
+            let file = temporaryDirectory.appending(component: "test")
+            try await subject.touch(file)
+
+            // When
+            try await subject.remove(file)
+
+            // Then
+            let exists = try await subject.exists(file)
+            XCTAssertFalse(exists)
+        }
+    }
+
+    func test_remove_directory_with_files() async throws {
+        try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+            // Given
+            let directory = temporaryDirectory.appending(component: "directory")
+            let nestedDirectory = directory.appending(component: "nested")
+            let file = nestedDirectory.appending(component: "test")
+            try await subject.makeDirectory(at: nestedDirectory)
+            try await subject.touch(file)
+
+            // When
+            try await subject.remove(directory)
+
+            // Then
+            let directoryExists = try await subject.exists(directory)
+            let nestedDirectoryExists = try await subject.exists(nestedDirectory)
+            let fileExists = try await subject.exists(file)
+            XCTAssertFalse(directoryExists)
+            XCTAssertFalse(nestedDirectoryExists)
+            XCTAssertFalse(fileExists)
+        }
+    }
 }


### PR DESCRIPTION
As flagged in https://github.com/apple/swift-nio/issues/2933, the `NIOFileSystem` removal performance is abysmal. Ideally, we'd do a fix in `swift-nio`, but for now, the quicker solution is to move to `FileManager`.