### PR TITLE
fix: removing non-existing file or directory

### DIFF
--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -296,6 +296,7 @@ public struct FileSystem: FileSysteming, Sendable {
 
     public func remove(_ path: AbsolutePath) async throws {
         logger?.debug("Removing the file or directory at path: \(path.pathString).")
+        guard try await exists(path) else { return }
         try await Task {
             try FileManager.default.removeItem(atPath: path.pathString)
         }

--- a/Tests/FileSystemTests/FileSystemTests.swift
+++ b/Tests/FileSystemTests/FileSystemTests.swift
@@ -902,6 +902,16 @@ final class FileSystemTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    func test_remove_non_existing_file() async throws {
+        try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+            // Given
+            let file = temporaryDirectory.appending(component: "test")
+
+            // When / Then
+            try await subject.remove(file)
+        }
+    }
+
     func test_remove_directory_with_files() async throws {
         try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
             // Given


### PR DESCRIPTION
When updating `FileSystem` in `tuist/tuist`, I noticed that the new `remove` implementation throws when deleting a file that doesn't exist – unlike the original `swift-nio` implementation.