### PR TITLE
fix: recreating directory when on concurrent move

### DIFF
--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -337,7 +337,7 @@ public struct FileSystem: FileSysteming, Sendable {
         do {
             if options.contains(.createTargetParentDirectories) {
                 if !(try await exists(to.parentDirectory, isDirectory: true)) {
-                    try await makeDirectory(at: to.parentDirectory, options: [.createTargetParentDirectories])
+                    try? await makeDirectory(at: to.parentDirectory, options: [.createTargetParentDirectories])
                 }
             }
             try await NIOFileSystem.FileSystem.shared.moveItem(at: .init(from.pathString), to: .init(to.pathString))


### PR DESCRIPTION
When `move` is run concurrently, we could try to make a directory that already exists. As a hotfix, we're ignoring the error. If the directory was not created, the following line when moving the file would fail, so we're not fully ignoring this error.