### PR TITLE
fix: unstable ZIPFoundation version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -57,10 +57,10 @@
     {
       "identity" : "zipfoundation",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/weichsel/ZIPFoundation",
+      "location" : "https://github.com/tuist/ZIPFoundation",
       "state" : {
-        "branch" : "development",
-        "revision" : "e9b1917bd4d7d050e0ff4ec157b5d6e253c84385"
+        "revision" : "e9b1917bd4d7d050e0ff4ec157b5d6e253c84385",
+        "version" : "0.9.20"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.8")),
         .package(url: "https://github.com/apple/swift-nio", .upToNextMajor(from: "2.79.0")),
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.6.2")),
-        .package(url: "https://github.com/weichsel/ZIPFoundation", branch: "development"),
+        .package(url: "https://github.com/tuist/ZIPFoundation", .upToNextMajor(from: "0.9.20")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
The https://github.com/tuist/FileSystem/pull/103 PR updated `ZIPFoundation` to an unstable version to fix compilation issues on Linux. However, unstable versions cause issues for consumers. In general, it's better to use a fork with a new version of a library instead.