### PR TITLE
fix: temporary directory to return direct path instead of symlink

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "ba72f31e11275fc5bf060c966cf6c1f36842a291",
-        "version" : "2.79.0"
+        "revision" : "dff45738d84a53dbc8ee899c306b3a7227f54f89",
+        "version" : "2.80.0"
       }
     },
     {

--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -314,9 +314,11 @@ public struct FileSystem: FileSysteming, Sendable {
 
         /// The path to the directory /var is a symlink to /var/private.
         /// NSTemporaryDirectory() returns the path to the symlink, so the logic here removes the symlink from it.
-//        if systemTemporaryDirectory.starts(with: "/var/") {
-//            systemTemporaryDirectory = "/private\(systemTemporaryDirectory)"
-//        }
+        #if os(macOS)
+            if systemTemporaryDirectory.starts(with: "/var/") {
+                systemTemporaryDirectory = "/private\(systemTemporaryDirectory)"
+            }
+        #endif
         let temporaryDirectory = try AbsolutePath(validating: systemTemporaryDirectory)
             .appending(component: "\(prefix)-\(UUID().uuidString)")
         logger?.debug("Creating a temporary directory at path \(temporaryDirectory.pathString).")


### PR DESCRIPTION
I accidentally commented out this piece of code in https://github.com/tuist/FileSystem/pull/103 as pointed by @ajkolean: https://github.com/tuist/FileSystem/pull/103#discussion_r1942239432

I'm bringing it back behind a `macOS` compiler directive.