### PR TITLE
fix: ignore .gitkeep results when globbing

### DIFF
--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -722,6 +722,7 @@ public struct FileSystem: FileSysteming, Sendable {
                 .map { try Pattern($0) },
             exclude: [
                 try Pattern("**/.DS_Store"),
+                try Pattern("**/.gitkeep"),
             ],
             skipHiddenFiles: false
         )

--- a/Tests/FileSystemTests/FileSystemTests.swift
+++ b/Tests/FileSystemTests/FileSystemTests.swift
@@ -857,6 +857,30 @@ final class FileSystemTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    func test_glob_with_nested_files_and_only_a_directory_wildcard_when_git_keep_is_present() async throws {
+        try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+            // Given
+            let firstDirectory = temporaryDirectory.appending(component: "first")
+            let secondDirectory = firstDirectory.appending(component: "second")
+            let sourceFile = firstDirectory.appending(component: "file.swift")
+            try await subject.makeDirectory(at: secondDirectory)
+            try await subject.touch(sourceFile)
+            try await subject.touch(firstDirectory.appending(component: ".gitkeep"))
+            try await subject.touch(secondDirectory.appending(component: ".gitkeep"))
+
+            // When
+            let got = try await subject.glob(
+                directory: temporaryDirectory,
+                include: ["**"]
+            )
+            .collect()
+            .sorted()
+
+            // Then
+            XCTAssertEqual(got, [firstDirectory, sourceFile, secondDirectory])
+        }
+    }
+
     func test_glob_with_symlink_and_only_a_directory_wildcard() async throws {
         try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
             // Given


### PR DESCRIPTION
Related: https://github.com/tuist/tuist/issues/7491

.gitkeep should be excluded by default.