### PR TITLE
feat: add defaults to the `inTemporaryDirectory` to improve the convenience of the API

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "c51907a839e63ebf0ba2076bba73dd96436bd1b9",
-        "version" : "2.81.0"
+        "revision" : "0f54d58bb5db9e064f332e8524150de379d1e51c",
+        "version" : "2.82.1"
       }
     },
     {

--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -754,7 +754,7 @@ extension FilePath {
 }
 
 extension FileSystem {
-    /// Creates and passes a temporary to the given action coupling its lifecycle to the action's.
+    /// Creates and passes a temporary directory to the given action, coupling its lifecycle to the action's.
     /// - Parameter action: The action to run with the temporary directory.
     /// - Returns: Any value returned by the action.
     public func runInTemporaryDirectory<T>(

--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -754,6 +754,15 @@ extension FilePath {
 }
 
 extension FileSystem {
+    /// Creates and passes a temporary to the given action coupling its lifecycle to the action's.
+    /// - Parameter action: The action to run with the temporary directory.
+    /// - Returns: Any value returned by the action.
+    public func runInTemporaryDirectory<T>(
+        _ action: @Sendable (_ temporaryDirectory: AbsolutePath) async throws -> T
+    ) async throws -> T {
+        try await runInTemporaryDirectory(prefix: UUID().uuidString, action)
+    }
+
     public func writeText(_ text: String, at path: AbsolutePath, options: Set<WriteTextOptions>) async throws {
         try await writeText(text, at: path, encoding: .utf8, options: options)
     }


### PR DESCRIPTION
I noticed when using `fileSystem.inTemporaryDirectory` we always pass the same value to `prefix`, `UUID().uuidString`, so I extended the `FileSysteming` extension to pass it by default.