### PR TITLE
feat: add a Swift Testing trait to create and scope a temporary directory to a test or suite lifecycle

### DIFF
--- a/.github/workflows/file-system.yml
+++ b/.github/workflows/file-system.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  MISE_EXPERIMENTAL: "1"
 
 concurrency:
   group: file-system-${{ github.head_ref }}
@@ -21,8 +22,6 @@ jobs:
       - uses: actions/checkout@v4
       - run: sudo xcode-select -s /Applications/Xcode_16.3.app
       - uses: jdx/mise-action@v2
-        with:
-          experimental: true
       - name: Run
         run: mise run build-spm
 
@@ -31,9 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: swift-actions/setup-swift@v2
         with:
-          experimental: true
+          swift-version: "6.1"
+      - uses: jdx/mise-action@v2
       - name: Run
         run: mise run build-linux
 
@@ -44,8 +44,6 @@ jobs:
       - uses: actions/checkout@v4
       - run: sudo xcode-select -s /Applications/Xcode_16.3.app
       - uses: jdx/mise-action@v2
-        with:
-          experimental: true
       - name: Run
         run: mise run test-spm
 
@@ -54,9 +52,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: swift-actions/setup-swift@v2
         with:
-          experimental: true
+          swift-version: "6.1"
+      - uses: jdx/mise-action@v2
       - name: Run
         run: mise run test-linux
 
@@ -67,7 +66,5 @@ jobs:
       - uses: actions/checkout@v4
       - run: sudo xcode-select -s /Applications/Xcode_16.3.app
       - uses: jdx/mise-action@v2
-        with:
-          experimental: true
       - name: Run
         run: mise run lint

--- a/.github/workflows/file-system.yml
+++ b/.github/workflows/file-system.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      - run: xcode-select -s /Applications/Xcode_16.3.app
+      - run: sudo xcode-select -s /Applications/Xcode_16.3.app
       - uses: jdx/mise-action@v2
         with:
           experimental: true
@@ -42,7 +42,7 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      - run: xcode-select -s /Applications/Xcode_16.3.app
+      - run: sudo xcode-select -s /Applications/Xcode_16.3.app
       - uses: jdx/mise-action@v2
         with:
           experimental: true
@@ -65,7 +65,7 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      - run: xcode-select -s /Applications/Xcode_16.3.app
+      - run: sudo xcode-select -s /Applications/Xcode_16.3.app
       - uses: jdx/mise-action@v2
         with:
           experimental: true

--- a/.github/workflows/file-system.yml
+++ b/.github/workflows/file-system.yml
@@ -30,9 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.1"
       - uses: jdx/mise-action@v2
       - name: Run
         run: mise run build-linux
@@ -52,9 +49,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.1"
       - uses: jdx/mise-action@v2
       - name: Run
         run: mise run test-linux

--- a/.github/workflows/file-system.yml
+++ b/.github/workflows/file-system.yml
@@ -15,10 +15,11 @@ concurrency:
 
 jobs:
   build:
-    name: "Release build on macOS 14"
-    runs-on: macos-14
+    name: "Release build on macOS"
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      - run: xcode-select -s /Applications/Xcode_16.3.app
       - uses: jdx/mise-action@v2
         with:
           experimental: true
@@ -37,10 +38,11 @@ jobs:
         run: mise run build-linux
 
   test:
-    name: "Test on macOS 14"
-    runs-on: macos-14
+    name: "Test on macOS"
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      - run: xcode-select -s /Applications/Xcode_16.3.app
       - uses: jdx/mise-action@v2
         with:
           experimental: true
@@ -60,9 +62,10 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      - run: xcode-select -s /Applications/Xcode_16.3.app
       - uses: jdx/mise-action@v2
         with:
           experimental: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,22 +50,16 @@ jobs:
       - name: Get next version
         id: next-version
         if: env.should-release == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo "NEXT_VERSION=$(git cliff --bumped-version)" >> "$GITHUB_OUTPUT"
       - name: Get release notes
         id: release-notes
         if: env.should-release == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "RELEASE_NOTES<<EOF" >> "$GITHUB_OUTPUT"
           git cliff --unreleased >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Update CHANGELOG.md
         if: env.should-release == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: git cliff --bump -o CHANGELOG.md
       - name: Commit changes
         id: auto-commit-action

--- a/.mise/tasks/build-linux
+++ b/.mise/tasks/build-linux
@@ -12,6 +12,6 @@ fi
 $CONTAINER_RUNTIME run --rm \
     --volume "$MISE_PROJECT_ROOT:/package" \
     --workdir "/package" \
-    swift:6.0.3 \
+    swift:6.1.0 \
     /bin/bash -c \
     "swift build --configuration release --build-path ./.build/linux"

--- a/.mise/tasks/test-linux
+++ b/.mise/tasks/test-linux
@@ -12,6 +12,6 @@ fi
 $CONTAINER_RUNTIME run --rm \
     --volume "$MISE_PROJECT_ROOT:/package" \
     --workdir "/package" \
-    swift:6.0.3 \
+    swift:6.1.0 \
     /bin/bash -c \
     "swift test"

--- a/Sources/FileSystem/FileSystemTestingTrait.swift
+++ b/Sources/FileSystem/FileSystemTestingTrait.swift
@@ -1,5 +1,4 @@
-#if DEBUG
-    #if canImport(Testing)
+#if DEBUG && canImport(Testing)
         import Path
         import Testing
 

--- a/Sources/FileSystem/FileSystemTestingTrait.swift
+++ b/Sources/FileSystem/FileSystemTestingTrait.swift
@@ -10,7 +10,7 @@
             @TaskLocal public static var testTemporaryDirectory: AbsolutePath?
         }
 
-        public struct FileSystemTestingTrait: TestTrait, SuiteTrait, TestScoping {
+        public struct FileSystemTestingTrait: TestTrait, SuiteTrait {
             public func provideScope(
                 for _: Test,
                 testCase _: Test.Case?,

--- a/Sources/FileSystem/FileSystemTestingTrait.swift
+++ b/Sources/FileSystem/FileSystemTestingTrait.swift
@@ -1,31 +1,31 @@
-// #if DEBUG && canImport(Testing)
-import Path
-import Testing
+#if DEBUG && canImport(Testing)
+    import Path
+    import Testing
 
-extension FileSystem {
-    /// It returns the temporary directory created when using the `@Test(.inTemporaryDirectory)`.
-    /// Note that since the value is only propagated through Swift structured concurrency, if you use DispatchQueue,
-    /// values won't be propagated so you'll have to make sure they are explicitly passed down.
-    @TaskLocal public static var temporaryTestDirectory: AbsolutePath?
-}
+    extension FileSystem {
+        /// It returns the temporary directory created when using the `@Test(.inTemporaryDirectory)`.
+        /// Note that since the value is only propagated through Swift structured concurrency, if you use DispatchQueue,
+        /// values won't be propagated so you'll have to make sure they are explicitly passed down.
+        @TaskLocal public static var temporaryTestDirectory: AbsolutePath?
+    }
 
-public struct FileSystemTestingTrait: TestTrait, SuiteTrait, TestScoping {
-    public func provideScope(
-        for _: Test,
-        testCase _: Test.Case?,
-        performing function: @Sendable () async throws -> Void
-    ) async throws {
-        try await FileSystem().runInTemporaryDirectory { temporaryDirectory in
-            try await FileSystem.$temporaryTestDirectory.withValue(temporaryDirectory) {
-                try await function()
+    public struct FileSystemTestingTrait: TestTrait, SuiteTrait, TestScoping {
+        public func provideScope(
+            for _: Test,
+            testCase _: Test.Case?,
+            performing function: @Sendable () async throws -> Void
+        ) async throws {
+            try await FileSystem().runInTemporaryDirectory { temporaryDirectory in
+                try await FileSystem.$temporaryTestDirectory.withValue(temporaryDirectory) {
+                    try await function()
+                }
             }
         }
     }
-}
 
-extension Trait where Self == FileSystemTestingTrait {
-    /// Creates a temporary directory and scopes its lifecycle to the lifecycle of the test.
-    public static var inTemporaryDirectory: Self { Self() }
-}
+    extension Trait where Self == FileSystemTestingTrait {
+        /// Creates a temporary directory and scopes its lifecycle to the lifecycle of the test.
+        public static var inTemporaryDirectory: Self { Self() }
+    }
 
-// #endif
+#endif

--- a/Sources/FileSystem/FileSystemTestingTrait.swift
+++ b/Sources/FileSystem/FileSystemTestingTrait.swift
@@ -1,0 +1,32 @@
+#if DEBUG
+    #if canImport(Testing)
+        import Path
+        import Testing
+
+        extension FileSystem {
+            /// It returns the temporary directory created when using the `@Test(.inTemporaryDirectory)`.
+            /// Note that since the value is only propagated through Swift structured concurrency, if you use DispatchQueue,
+            /// values won't be propagated so you'll have to make sure they are explicitly passed down.
+            @TaskLocal public static var testTemporaryDirectory: AbsolutePath?
+        }
+
+        public struct FileSystemTestingTrait: TestTrait, SuiteTrait, TestScoping {
+            public func provideScope(
+                for _: Test,
+                testCase _: Test.Case?,
+                performing function: @Sendable () async throws -> Void
+            ) async throws {
+                try await FileSystem().runInTemporaryDirectory { temporaryDirectory in
+                    try await FileSystem.$testTemporaryDirectory.withValue(temporaryDirectory) {
+                        try await function()
+                    }
+                }
+            }
+        }
+
+        extension Trait where Self == FileSystemTestingTrait {
+            /// Creates a temporary directory and scopes its lifecycle to the lifecycle of the test.
+            public static var inTemporaryDirectory: Self { Self() }
+        }
+    #endif
+#endif

--- a/Sources/FileSystem/FileSystemTestingTrait.swift
+++ b/Sources/FileSystem/FileSystemTestingTrait.swift
@@ -9,7 +9,7 @@ extension FileSystem {
     @TaskLocal public static var temporaryTestDirectory: AbsolutePath?
 }
 
-public struct FileSystemTestingTrait: TestTrait, SuiteTrait {
+public struct FileSystemTestingTrait: TestTrait, SuiteTrait, TestScoping {
     public func provideScope(
         for _: Test,
         testCase _: Test.Case?,

--- a/Sources/FileSystem/FileSystemTestingTrait.swift
+++ b/Sources/FileSystem/FileSystemTestingTrait.swift
@@ -1,4 +1,4 @@
-#if DEBUG && canImport(Testing)
+#if DEBUG && canImport(Testing) && compiler(>=6.1)
     import Path
     import Testing
 

--- a/Sources/FileSystem/FileSystemTestingTrait.swift
+++ b/Sources/FileSystem/FileSystemTestingTrait.swift
@@ -1,31 +1,31 @@
-#if DEBUG && canImport(Testing)
-        import Path
-        import Testing
+// #if DEBUG && canImport(Testing)
+import Path
+import Testing
 
-        extension FileSystem {
-            /// It returns the temporary directory created when using the `@Test(.inTemporaryDirectory)`.
-            /// Note that since the value is only propagated through Swift structured concurrency, if you use DispatchQueue,
-            /// values won't be propagated so you'll have to make sure they are explicitly passed down.
-            @TaskLocal public static var temporaryTestDirectory: AbsolutePath?
-        }
+extension FileSystem {
+    /// It returns the temporary directory created when using the `@Test(.inTemporaryDirectory)`.
+    /// Note that since the value is only propagated through Swift structured concurrency, if you use DispatchQueue,
+    /// values won't be propagated so you'll have to make sure they are explicitly passed down.
+    @TaskLocal public static var temporaryTestDirectory: AbsolutePath?
+}
 
-        public struct FileSystemTestingTrait: TestTrait, SuiteTrait {
-            public func provideScope(
-                for _: Test,
-                testCase _: Test.Case?,
-                performing function: @Sendable () async throws -> Void
-            ) async throws {
-                try await FileSystem().runInTemporaryDirectory { temporaryDirectory in
-                    try await FileSystem.$testTemporaryDirectory.withValue(temporaryDirectory) {
-                        try await function()
-                    }
-                }
+public struct FileSystemTestingTrait: TestTrait, SuiteTrait {
+    public func provideScope(
+        for _: Test,
+        testCase _: Test.Case?,
+        performing function: @Sendable () async throws -> Void
+    ) async throws {
+        try await FileSystem().runInTemporaryDirectory { temporaryDirectory in
+            try await FileSystem.$temporaryTestDirectory.withValue(temporaryDirectory) {
+                try await function()
             }
         }
+    }
+}
 
-        extension Trait where Self == FileSystemTestingTrait {
-            /// Creates a temporary directory and scopes its lifecycle to the lifecycle of the test.
-            public static var inTemporaryDirectory: Self { Self() }
-        }
-    #endif
-#endif
+extension Trait where Self == FileSystemTestingTrait {
+    /// Creates a temporary directory and scopes its lifecycle to the lifecycle of the test.
+    public static var inTemporaryDirectory: Self { Self() }
+}
+
+// #endif

--- a/Sources/FileSystem/FileSystemTestingTrait.swift
+++ b/Sources/FileSystem/FileSystemTestingTrait.swift
@@ -6,7 +6,7 @@
             /// It returns the temporary directory created when using the `@Test(.inTemporaryDirectory)`.
             /// Note that since the value is only propagated through Swift structured concurrency, if you use DispatchQueue,
             /// values won't be propagated so you'll have to make sure they are explicitly passed down.
-            @TaskLocal public static var testTemporaryDirectory: AbsolutePath?
+            @TaskLocal public static var temporaryTestDirectory: AbsolutePath?
         }
 
         public struct FileSystemTestingTrait: TestTrait, SuiteTrait {

--- a/Tests/FileSystemTests/FileSystemTestingTraitTests.swift
+++ b/Tests/FileSystemTests/FileSystemTestingTraitTests.swift
@@ -1,0 +1,13 @@
+import FileSystem
+import Testing
+
+struct FileSystemTestingTraitTestsTests {
+    @Test(.inTemporaryDirectory) func testTemporaryDirectory() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.testTemporaryDirectory)
+        let filePath = temporaryDirectory.appending(component: "test")
+
+        // Then
+        try await FileSystem().touch(filePath)
+    }
+}

--- a/Tests/FileSystemTests/FileSystemTestingTraitTests.swift
+++ b/Tests/FileSystemTests/FileSystemTestingTraitTests.swift
@@ -1,7 +1,7 @@
 import FileSystem
 import Testing
 
-struct FileSystemTestingTraitTestsTests {
+struct FileSystemTestingTraitTests {
     @Test(.inTemporaryDirectory) func testTemporaryDirectory() async throws {
         // Given
         let temporaryDirectory = try #require(FileSystem.testTemporaryDirectory)

--- a/Tests/FileSystemTests/FileSystemTestingTraitTests.swift
+++ b/Tests/FileSystemTests/FileSystemTestingTraitTests.swift
@@ -4,7 +4,7 @@ import Testing
 struct FileSystemTestingTraitTests {
     @Test(.inTemporaryDirectory) func testTemporaryDirectory() async throws {
         // Given
-        let temporaryDirectory = try #require(FileSystem.testTemporaryDirectory)
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let filePath = temporaryDirectory.appending(component: "test")
 
         // Then


### PR DESCRIPTION
Drawing inspiration from `ExUnit.Case` [tmp dir](https://hexdocs.pm/ex_unit/main/ExUnit.Case.html#module-tmp-dir) tag, I'm adding a custom Swift Testing trait to create a temporary directory and scope its lifecycle to the test ore suite's.

```swift
@Test(.inTemporaryDirectory) func exampleTest() async throws {
  let temporaryDirectory = try #require(FileSystem.testTemporaryDirectory)
}
```