### PR TITLE
feat: expose Glob target as a package product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,11 @@ let package = Package(
             type: .static,
             targets: ["FileSystemTesting"]
         ),
+        .library(
+            name: "Glob",
+            type: .static,
+            targets: ["Glob"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/tuist/Path", .upToNextMajor(from: "0.3.8")),


### PR DESCRIPTION
It's not necessarily designed to be used directly, but Glob is pretty handy to use on its own in some cases, so wondering if you would be willing to expose it as its own package product 🙏 