### PR TITLE
feat:  add API to get the metadata of a particular file

### DIFF
--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -20,3 +20,6 @@ jobs:
       - uses: CondeNast/conventional-pull-request-action@v0.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commitTitleMatch: false
+          ignoreCommits: true # PRs are merged squashing with the commit title matching the PR title.

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "34d486b01cd891297ac615e40d5999536a1e138d",
-        "version" : "2.83.0"
+        "revision" : "a5fea865badcb1c993c85b0f0e8d05a4bd2270fb",
+        "version" : "2.85.0"
       }
     },
     {

--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -633,7 +633,7 @@ public struct FileSystem: FileSysteming, Sendable {
     }
 
     public func fileLastModificationDate(at path: AbsolutePath) async throws -> Date? {
-        logger?.debug("Getting the size in bytes of file at path \(path.pathString).")
+        logger?.debug("Getting the last modification date of file at path \(path.pathString).")
         guard let info = try await NIOFileSystem.FileSystem.shared.info(
             forFileAt: .init(path.pathString),
             infoAboutSymbolicLink: true

--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -11,6 +11,14 @@ public enum FileSystemItemType: CaseIterable, Equatable {
     case file
 }
 
+public struct FileMetadata {
+    /// The size of the file in bytes.
+    var size: Int64
+
+    /// The date the file was last modified.
+    var lastModificationDate: Date
+}
+
 public enum FileSystemError: Equatable, Error, CustomStringConvertible {
     case moveNotFound(from: AbsolutePath, to: AbsolutePath)
     case makeDirectoryAbsentParent(AbsolutePath)
@@ -237,12 +245,18 @@ public protocol FileSysteming {
     /// Returns the size of a file at a given path. If the file doesn't exist, it returns nil.
     /// - Parameter at: Path to the file whose size will be returned.
     /// - Returns: The file size, otherwise `nil`
+    @available(
+        *,
+        deprecated,
+        renamed: "fileMetadata",
+        message: "Read the file size from the metadata, which contains other attributes"
+    )
     func fileSizeInBytes(at: AbsolutePath) async throws -> Int64?
 
-    /// Returns the date when a file was last modified. If the file doesn't exist, it returns nil.
+    /// Returns metadata of a file at a given path.
     /// - Parameter path: Absolute path to the file.
-    /// - Returns: The date it was last modified.
-    func fileLastModificationDate(at path: AbsolutePath) async throws -> Date?
+    /// - Returns: The file metadata.
+    func fileMetadata(at path: AbsolutePath) async throws -> FileMetadata?
 
     /// Given a path, it replaces it with the file or directory at the other path.
     /// - Parameters:
@@ -623,6 +637,12 @@ public struct FileSystem: FileSysteming, Sendable {
         }
     }
 
+    @available(
+        *,
+        deprecated,
+        renamed: "fileMetadata",
+        message: "Read the file size from the metadata, which contains other attributes"
+    )
     public func fileSizeInBytes(at path: AbsolutePath) async throws -> Int64? {
         logger?.debug("Getting the size in bytes of file at path \(path.pathString).")
         guard let info = try await NIOFileSystem.FileSystem.shared.info(
@@ -632,15 +652,15 @@ public struct FileSystem: FileSysteming, Sendable {
         return info.size
     }
 
-    public func fileLastModificationDate(at path: AbsolutePath) async throws -> Date? {
-        logger?.debug("Getting the last modification date of file at path \(path.pathString).")
+    public func fileMetadata(at path: AbsolutePath) async throws -> FileMetadata? {
+        logger?.debug("Getting the metadata of file at path \(path.pathString).")
         guard let info = try await NIOFileSystem.FileSystem.shared.info(
             forFileAt: .init(path.pathString),
             infoAboutSymbolicLink: true
         ) else { return nil }
         let lastModified = info.lastDataModificationTime
         let modificationTimeInterval = Double(lastModified.seconds) + Double(lastModified.nanoseconds) / 1_000_000_000
-        return Date(timeIntervalSince1970: modificationTimeInterval)
+        return FileMetadata(size: info.size, lastModificationDate: Date(timeIntervalSince1970: modificationTimeInterval))
     }
 
     public func locateTraversingUp(from: AbsolutePath, relativePath: RelativePath) async throws -> AbsolutePath? {

--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -11,12 +11,13 @@ public enum FileSystemItemType: CaseIterable, Equatable {
     case file
 }
 
+/// A struct containing information about a particular file.
 public struct FileMetadata {
     /// The size of the file in bytes.
-    var size: Int64
+    public let size: Int64
 
     /// The date the file was last modified.
-    var lastModificationDate: Date
+    public let lastModificationDate: Date
 }
 
 public enum FileSystemError: Equatable, Error, CustomStringConvertible {

--- a/Tests/FileSystemTests/FileSystemTests.swift
+++ b/Tests/FileSystemTests/FileSystemTests.swift
@@ -273,6 +273,33 @@ final class FileSystemTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    func test_fileLastModificationDate_when_fileAbsent() async throws {
+        try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+            // Given
+            let path = temporaryDirectory.appending(component: "file")
+
+            // When
+            let modificationDate = try await subject.fileLastModificationDate(at: path)
+
+            // Then
+            XCTAssertNil(modificationDate)
+        }
+    }
+
+    func test_fileLastModificationDate_when_filePresent() async throws {
+        try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+            // Given
+            let path = temporaryDirectory.appending(component: "file")
+            try await subject.touch(path)
+
+            // When
+            let modificationDate = try await subject.fileLastModificationDate(at: path)
+
+            // Then
+            XCTAssertNotNil(modificationDate)
+        }
+    }
+
     func test_replace_replaces_when_replacingPathIsADirectory_and_targetDirectoryIsAbsent() async throws {
         try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
             // Given

--- a/Tests/FileSystemTests/FileSystemTests.swift
+++ b/Tests/FileSystemTests/FileSystemTests.swift
@@ -273,30 +273,30 @@ final class FileSystemTests: XCTestCase, @unchecked Sendable {
         }
     }
 
-    func test_fileLastModificationDate_when_fileAbsent() async throws {
+    func test_fileMetadata_when_fileAbsent() async throws {
         try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
             // Given
             let path = temporaryDirectory.appending(component: "file")
 
             // When
-            let modificationDate = try await subject.fileLastModificationDate(at: path)
+            let modificationDate = try await subject.fileMetadata(at: path)
 
             // Then
             XCTAssertNil(modificationDate)
         }
     }
 
-    func test_fileLastModificationDate_when_filePresent() async throws {
+    func test_fileMetadata_when_filePresent() async throws {
         try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
             // Given
             let path = temporaryDirectory.appending(component: "file")
             try await subject.touch(path)
 
             // When
-            let modificationDate = try await subject.fileLastModificationDate(at: path)
+            let metadata = try await subject.fileMetadata(at: path)
 
             // Then
-            XCTAssertNotNil(modificationDate)
+            XCTAssertNotNil(metadata?.lastModificationDate)
         }
     }
 


### PR DESCRIPTION
While [solving](https://github.com/tuist/tuist/pull/7907) the race condition with auth in Tuist, I came across to detect if a lockfile is present but old, and I realized we don't have an API for that in FileSystem, so I'm adding it.