### PR TITLE
fix: add Musl support to File System Primitives

### DIFF
--- a/.github/workflows/file-system.yml
+++ b/.github/workflows/file-system.yml
@@ -35,6 +35,39 @@ jobs:
       - name: Run
         run: mise run build-linux
 
+  build-musl:
+    name: "Release build on Static Linux SDK (${{ matrix.arch }})"
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: swift:6.2
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+            sdk-target: x86_64-swift-linux-musl
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+            sdk-target: aarch64-swift-linux-musl
+    steps:
+      - uses: actions/checkout@v6
+      - name: Cache Static Linux SDK
+        uses: actions/cache@v4
+        with:
+          path: ~/.swiftpm/swift-sdks
+          key: static-linux-sdk-swift-6.2.3-${{ matrix.arch }}
+      - name: Install Swift Static Linux SDK
+        run: |
+          if ! swift sdk list | grep -q "swift-6.2.3-RELEASE_static-linux"; then
+            swift sdk install \
+              https://download.swift.org/swift-6.2.3-release/static-sdk/swift-6.2.3-RELEASE/swift-6.2.3-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
+              --checksum f30ec724d824ef43b5546e02ca06a8682dafab4b26a99fbb0e858c347e507a2c
+          fi
+      - name: Build
+        run: swift build --configuration release --build-path ./.build/musl --swift-sdk ${{ matrix.sdk-target }}
+
   test:
     name: "Test on macOS"
     runs-on: macos-15

--- a/.mise/tasks/build-musl
+++ b/.mise/tasks/build-musl
@@ -1,0 +1,46 @@
+#!/bin/bash
+# mise description="Builds the project with the Swift Static Linux SDK (Musl) for the host architecture"
+set -euo pipefail
+
+CONTAINER_RUNTIME=$(command -v podman || command -v docker || true)
+
+if [ -z "$CONTAINER_RUNTIME" ]; then
+  echo "Neither podman nor docker is available. Please install one to proceed."
+  exit 1
+fi
+
+# If we're not inside a Linux container, re-invoke this script inside one so the
+# Static Linux SDK (which targets Linux hosts) works consistently across macOS
+# and Linux developer machines.
+if [ "${INSIDE_MUSL_CONTAINER:-}" != "1" ]; then
+  exec $CONTAINER_RUNTIME run --rm \
+      --volume "$MISE_PROJECT_ROOT:/package" \
+      --workdir "/package" \
+      --env INSIDE_MUSL_CONTAINER=1 \
+      swift:6.2 \
+      /package/.mise/tasks/build-musl
+fi
+
+SDK_URL="https://download.swift.org/swift-6.2.3-release/static-sdk/swift-6.2.3-RELEASE/swift-6.2.3-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz"
+SDK_CHECKSUM="f30ec724d824ef43b5546e02ca06a8682dafab4b26a99fbb0e858c347e507a2c"
+
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64)  SDK_TARGET="x86_64-swift-linux-musl" ;;
+  aarch64) SDK_TARGET="aarch64-swift-linux-musl" ;;
+  *)
+    echo "ERROR: Unsupported architecture: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+echo "==> Installing Swift Static Linux SDK (if not already installed)"
+if ! swift sdk list | grep -q "swift-6.2.3-RELEASE_static-linux"; then
+  swift sdk install "$SDK_URL" --checksum "$SDK_CHECKSUM"
+fi
+
+echo "==> Building with $SDK_TARGET"
+swift build \
+  --configuration release \
+  --build-path ./.build/musl \
+  --swift-sdk "$SDK_TARGET"

--- a/Sources/File System Primitives/File.Descriptor+POSIX.swift
+++ b/Sources/File System Primitives/File.Descriptor+POSIX.swift
@@ -70,6 +70,8 @@
                 let fd = Darwin.open(path.string, flags, defaultMode)
             #elseif canImport(Glibc)
                 let fd = Glibc.open(path.string, flags, defaultMode)
+            #elseif canImport(Musl)
+                let fd = Musl.open(path.string, flags, defaultMode)
             #endif
 
             guard fd >= 0 else {

--- a/Sources/File System Primitives/File.Directory.Iterator.swift
+++ b/Sources/File System Primitives/File.Directory.Iterator.swift
@@ -32,8 +32,8 @@ extension File.Directory {
             private var _hasMore: Bool
         #elseif canImport(Darwin)
             private var _dir: UnsafeMutablePointer<DIR>?
-        #elseif canImport(Glibc)
-            // Use OpaquePointer on Linux (DIR type not exported in Swift's Glibc overlay)
+        #elseif canImport(Glibc) || canImport(Musl)
+            // Use OpaquePointer on Linux (DIR type not exported in Swift's Glibc/Musl overlay)
             private var _dir: OpaquePointer?
         #endif
         private let _basePath: File.Path
@@ -50,6 +50,10 @@ extension File.Directory {
             #elseif canImport(Glibc)
                 if let dir = _dir {
                     Glibc.closedir(dir)
+                }
+            #elseif canImport(Musl)
+                if let dir = _dir {
+                    Musl.closedir(dir)
                 }
             #endif
         }
@@ -111,6 +115,11 @@ extension File.Directory.Iterator {
         #elseif canImport(Glibc)
             if let dir = _dir {
                 Glibc.closedir(dir)
+                _dir = nil
+            }
+        #elseif canImport(Musl)
+            if let dir = _dir {
+                Musl.closedir(dir)
                 _dir = nil
             }
         #endif
@@ -197,7 +206,7 @@ extension File.Directory.Iterator {
             }
         }
     }
-#elseif canImport(Glibc)
+#elseif canImport(Glibc) || canImport(Musl)
     extension File.Directory.Iterator {
         private static func _openPOSIX(at path: File.Path) throws(Error) -> File.Directory.Iterator
         {
@@ -211,7 +220,7 @@ extension File.Directory.Iterator {
                 throw .notADirectory(path)
             }
 
-            guard let dir = Glibc.opendir(path.string) else {
+            guard let dir = opendir(path.string) else {
                 throw _mapErrno(errno, path: path)
             }
 
@@ -226,7 +235,7 @@ extension File.Directory.Iterator {
                 return nil
             }
 
-            while let entry = Glibc.readdir(dir) {
+            while let entry = readdir(dir) {
                 let name = String(posixDirectoryEntryName: entry.pointee.d_name)
 
                 // Skip . and ..
@@ -237,10 +246,10 @@ extension File.Directory.Iterator {
                 // Build full path using proper path composition
                 let entryPath = _basePath.appending(name)
 
-                // Determine type via lstat (Glibc doesn't reliably expose d_type)
+                // Determine type via lstat (Glibc/Musl don't reliably expose d_type)
                 let entryType: File.Directory.EntryType
                 var entryStat = stat()
-                if Glibc.lstat(entryPath.string, &entryStat) == 0 {
+                if lstat(entryPath.string, &entryStat) == 0 {
                     switch entryStat.st_mode & S_IFMT {
                     case S_IFREG:
                         entryType = .file

--- a/Sources/File System Primitives/File.Handle.swift
+++ b/Sources/File System Primitives/File.Handle.swift
@@ -203,6 +203,17 @@ extension File.Handle {
             if bytesRead < count {
                 buffer.removeLast(count - bytesRead)
             }
+        #elseif canImport(Musl)
+            let bytesRead = buffer.withUnsafeMutableBufferPointer { ptr -> Int in
+                guard let base = ptr.baseAddress else { return 0 }
+                return Musl.read(_descriptor.rawValue, base, count)
+            }
+            if bytesRead < 0 {
+                throw .readFailed(errno: errno, message: String(cString: strerror(errno)))
+            }
+            if bytesRead < count {
+                buffer.removeLast(count - bytesRead)
+            }
         #endif
 
         return buffer
@@ -241,6 +252,12 @@ extension File.Handle {
             return result
         #elseif canImport(Glibc)
             let result = Glibc.read(_descriptor.rawValue, buffer.baseAddress!, buffer.count)
+            if result < 0 {
+                throw .readFailed(errno: errno, message: String(cString: strerror(errno)))
+            }
+            return result
+        #elseif canImport(Musl)
+            let result = Musl.read(_descriptor.rawValue, buffer.baseAddress!, buffer.count)
             if result < 0 {
                 throw .readFailed(errno: errno, message: String(cString: strerror(errno)))
             }
@@ -305,6 +322,22 @@ extension File.Handle {
             while totalWritten < count {
                 let remaining = count - totalWritten
                 let w = Glibc.write(
+                    _descriptor.rawValue,
+                    base.advanced(by: totalWritten),
+                    remaining
+                )
+                if w > 0 {
+                    totalWritten += w
+                } else if w < 0 {
+                    if errno == EINTR { continue }
+                    throw .writeFailed(errno: errno, message: String(cString: strerror(errno)))
+                }
+            }
+        #elseif canImport(Musl)
+            var totalWritten = 0
+            while totalWritten < count {
+                let remaining = count - totalWritten
+                let w = Musl.write(
                     _descriptor.rawValue,
                     base.advanced(by: totalWritten),
                     remaining

--- a/Sources/File System Primitives/File.System.Write.Append.swift
+++ b/Sources/File System Primitives/File.System.Write.Append.swift
@@ -102,6 +102,8 @@ extension File.System.Write.Append {
                     let w = Darwin.write(fd, base.advanced(by: written), remaining)
                 #elseif canImport(Glibc)
                     let w = Glibc.write(fd, base.advanced(by: written), remaining)
+                #elseif canImport(Musl)
+                    let w = Musl.write(fd, base.advanced(by: written), remaining)
                 #endif
 
                 if w > 0 {

--- a/Sources/File System Primitives/File.System.Write.Atomic+POSIX.swift
+++ b/Sources/File System Primitives/File.System.Write.Atomic+POSIX.swift
@@ -9,6 +9,7 @@
         import CFileSystemShims
         import Glibc
     #elseif canImport(Musl)
+        import CFileSystemShims
         import Musl
     #endif
 

--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -4,8 +4,10 @@
     import _NIOFileSystem
     #if canImport(Darwin)
         import Darwin
-    #else
+    #elseif canImport(Glibc)
         import Glibc
+    #elseif canImport(Musl)
+        import Musl
     #endif
     import File_System_Primitives
     import NIOCore


### PR DESCRIPTION
## Summary

FileSystem 0.16.0 introduced new POSIX code paths in `Sources/File System Primitives/` that are guarded only by `canImport(Darwin)` / `canImport(Glibc)`. Building the package against the Swift Static Linux SDK — which uses Musl — fails with:

- `cannot find 'fd' in scope` in `File.Descriptor+POSIX.swift`
- `cannot find '_openPOSIX' / '_nextPOSIX' in scope` in `File.Directory.Iterator.swift`
- `cannot find 'w' in scope` in `File.System.Write.Append.swift`
- `cannot find 'atomicfilewrite_renameat2_noreplace' in scope` in `File.System.Write.Atomic+POSIX.swift`

This broke Tuist's `Release CLI (Linux aarch64)` job after bumping to 0.16.0 (tuist/tuist#10241).

The fix adds `#elseif canImport(Musl)` branches to the affected primitives:

- `File.Descriptor+POSIX.swift` — Musl branch for `open()`.
- `File.Directory.Iterator.swift` — Musl storage type, Musl branches for `closedir` in `deinit` and `close()`; merged the `_openPOSIX`/`_nextPOSIX` extension under `canImport(Glibc) || canImport(Musl)` using unprefixed POSIX calls (both overlays expose `opendir`, `readdir`, `lstat` at global scope).
- `File.Handle.swift` — Musl branches for `read`/`write` in three code paths.
- `File.System.Write.Append.swift` — Musl branch for `write()`.
- `File.System.Write.Atomic+POSIX.swift` — import `CFileSystemShims` under Musl as well. The C shim itself is already gated on `__linux__`, which applies to Musl.

The two `#if os(Linux) && canImport(Glibc)` fast paths in `File.System.Copy+POSIX.swift` gracefully fall back to the manual-copy loop when neither is available, so Musl hits the fallback — no change needed there for correctness.

## Test plan

- [ ] CI: build against Swift Static Linux SDK (Musl) on both x86_64 and aarch64
- [ ] CI: existing macOS / Linux-Glibc builds still pass
- [ ] Re-run the consumer `Release CLI (Linux aarch64)` build in tuist/tuist with a patched FileSystem pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)