### PR TITLE
fix: remove public extensions that silently shadow Foundation/stdlib

### DIFF
--- a/Sources/Binary/Binary.Serializable.swift
+++ b/Sources/Binary/Binary.Serializable.swift
@@ -192,30 +192,6 @@ extension StringProtocol {
     }
 }
 
-// MARK: - Direct Byte Array Conversions
-
-extension String {
-    /// Creates a string by decoding UTF-8 bytes.
-    ///
-    /// - Parameter bytes: The UTF-8 encoded bytes to decode
-    ///
-    /// Example:
-    /// ```swift
-    /// let bytes: [UInt8] = [72, 101, 108, 108, 111]
-    /// let string = String(bytes)  // "Hello"
-    /// ```
-    @inlinable
-    public init(_ bytes: [UInt8]) {
-        self = String(decoding: bytes, as: UTF8.self)
-    }
-
-    /// Creates a string by decoding UTF-8 bytes from an array slice.
-    @inlinable
-    public init(_ bytes: ArraySlice<UInt8>) {
-        self = String(decoding: bytes, as: UTF8.self)
-    }
-}
-
 // MARK: - RawRepresentable Default Implementations
 
 extension Binary.Serializable where Self: RawRepresentable, Self.RawValue: StringProtocol {

--- a/Sources/INCITS_4_1986/SetCharacter+INCITS_4_1986.swift
+++ b/Sources/INCITS_4_1986/SetCharacter+INCITS_4_1986.swift
@@ -46,7 +46,7 @@ extension Set<Character>.ASCII {
             INCITS_4_1986.whitespaces.map {
                 Character(UnicodeScalar($0))
             })
-        set.insert(Character(.init([UInt8].ascii.crlf)))
+        set.insert(Character(String(decoding: [UInt8].ascii.crlf, as: UTF8.self)))
         return set
     }()
 

--- a/Sources/StandardLibraryExtensions/Sequence.swift
+++ b/Sources/StandardLibraryExtensions/Sequence.swift
@@ -3,25 +3,6 @@
 //
 // Extensions for Swift standard library Sequence
 
-extension Sequence {
-    /// Counts elements satisfying predicate
-    ///
-    /// Measures cardinality of preimage under characteristic function.
-    /// Computes |f⁻¹(true)| where f: A → Bool is the predicate.
-    ///
-    /// Category theory: Composition of characteristic function with cardinality:
-    /// count: (A → Bool) → Seq(A) → ℕ where count(p, s) = |{x ∈ s : p(x)}|
-    ///
-    /// Example:
-    /// ```swift
-    /// [1, 2, 3, 4, 5].count(where: { $0.isMultiple(of: 2) })  // 2
-    /// ```
-    public func count(where predicate: (Element) throws -> Bool) rethrows -> Int {
-        try reduce(0) { try predicate($1) ? $0 + 1 : $0 }
-    }
-
-}
-
 extension Sequence where Element: Hashable {
     /// Computes frequency distribution of elements
     ///
@@ -99,61 +80,4 @@ extension Sequence where Element: Comparable {
         return true
     }
 
-    /// Returns N largest elements
-    ///
-    /// Partial order selection via top-N filter.
-    /// Selects maximal elements up to specified count.
-    ///
-    /// Category theory: Order-preserving projection to prefix:
-    /// max: ℕ → Seq(A) → Seq(A) where result is ordered maximum subset
-    ///
-    /// Example:
-    /// ```swift
-    /// [3, 1, 4, 1, 5, 9, 2].max(count: 3)  // [9, 5, 4]
-    /// ```
-    public func max(count: Int) -> [Element] {
-        guard count > 0 else { return [] }
-        var result: [Element] = []
-
-        for element in self {
-            if result.count < count {
-                result.append(element)
-                result.sort(by: >)
-            } else if let last = result.last, element > last {
-                result[count - 1] = element
-                result.sort(by: >)
-            }
-        }
-
-        return result
-    }
-
-    /// Returns N smallest elements
-    ///
-    /// Dual to max(count:), selects minimal elements.
-    /// Partial order selection via bottom-N filter.
-    ///
-    /// Category theory: Order-reversing variant of max:
-    /// min: ℕ → Seq(A) → Seq(A) where min ≡ max ∘ reverse_order
-    ///
-    /// Example:
-    /// ```swift
-    /// [3, 1, 4, 1, 5, 9, 2].min(count: 3)  // [1, 1, 2]
-    /// ```
-    public func min(count: Int) -> [Element] {
-        guard count > 0 else { return [] }
-        var result: [Element] = []
-
-        for element in self {
-            if result.count < count {
-                result.append(element)
-                result.sort()
-            } else if let last = result.last, element < last {
-                result[count - 1] = element
-                result.sort()
-            }
-        }
-
-        return result
-    }
 }


### PR DESCRIPTION
## Summary

Three public API-shape hazards that get statically linked via the `FileSystem` product and silently win overload resolution against Foundation or stdlib — the same shadowing pattern that caused the O(n²) `range(of:)` regression fixed in #325 (~16 ms per call in Tuist's `XCActivityLogParser`).

This is a **draft** so we can discuss scope and the semver implications (these are all `public`, so removal is source-breaking for any consumer that depended on them explicitly).

### Removed

- **`String.init(_ bytes: [UInt8])` / `String.init(_ bytes: ArraySlice<UInt8>)`** in `Sources/Binary/Binary.Serializable.swift`. Unlabeled public initializers that turn `String(someByteArray)` into a lossy UTF-8 decode (`String(decoding: bytes, as: UTF8.self)`) — invalid bytes become U+FFFD without the caller opting in. Highest correctness risk of the three because it's nearly invisible: any consumer writing `String(x)` for a byte-array `x` now silently gets replacement decoding instead of a compile error.
- **`Sequence.count(where:)`** in `Sources/StandardLibraryExtensions/Sequence.swift`. Duplicate of the Swift 6 stdlib built-in `Sequence.count(where:)`. A competing declaration creates overload-resolution ambiguity on Swift 6 consumers for zero functional benefit (same O(n), just `reduce`-wrapped).
- **`Sequence.max(count:)` / `Sequence.min(count:)`** in the same file. Collides with `swift-algorithms`' top-K APIs of the same name, causing ambiguous-overload errors for any consumer that depends on both. The implementation also full-sorts the result array per iteration, which is **O(N · K log K)** instead of the O(N log K) a proper partial-sort/heap would give — a footgun for large N.

### Internal call-site update

The only in-package consumer of `String.init(_ bytes: [UInt8])` was `Sources/INCITS_4_1986/SetCharacter+INCITS_4_1986.swift` building the CRLF `Character`. Rewritten to call `String(decoding:as:)` explicitly — same behavior, no hidden overload.

### Tests

`swift test` — 87 XCTest + 12 Swift Testing cases pass locally.

## Test plan

- [ ] CI green
- [ ] Confirm no downstream consumers relied on these specific inits / overloads
- [ ] Decide whether this is 0.17.0 (breaking) or a patch — leaning 0.17.0 since `String.init(_ bytes:)` is public API removal