### PR TITLE
fix: make concurrent file writes race-safe

### DIFF
--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -72,6 +72,11 @@ public enum MoveOptions: String {
 /// Options to configure the make directory operation.
 public enum MakeDirectoryOptions: String {
     /// When passed, it creates the parent directories if needed.
+    ///
+    /// This option carries full `mkdir -p` semantics: intermediate directories are created
+    /// as needed, and no error is raised if a directory already exists at the target path,
+    /// which makes it safe to call concurrently from multiple processes or tasks. A
+    /// non-directory file at the target path still raises an error.
     case createTargetParentDirectories
 }
 
@@ -719,17 +724,16 @@ public struct FileSystem: FileSysteming, Sendable {
         _ text: String,
         at path: AbsolutePath,
         encoding: String.Encoding,
-        options: Set<WriteTextOptions>
+        options _: Set<WriteTextOptions>
     ) async throws {
         logger?.debug("Writing text at path \(path.pathString).")
         guard let data = text.data(using: encoding) else {
             throw FileSystemError.cantEncodeText(text, encoding)
         }
 
-        if options.contains(.overwrite), try await exists(path) {
-            try await remove(path)
-        }
-
+        // The underlying writes (atomic write on POSIX, Data.write on Windows)
+        // both replace existing files atomically. We intentionally don't pre-check
+        // and remove — that pattern is racy under concurrent writers.
         #if os(Windows)
             try data.write(to: URL(fileURLWithPath: path.pathString))
         #else
@@ -759,13 +763,9 @@ public struct FileSystem: FileSysteming, Sendable {
         _ item: some Encodable,
         at path: AbsolutePath,
         encoder: PropertyListEncoder,
-        options: Set<WritePlistOptions>
+        options _: Set<WritePlistOptions>
     ) async throws {
         logger?.debug("Writing .plist at path \(path.pathString).")
-
-        if options.contains(.overwrite), try await exists(path) {
-            try await remove(path)
-        }
 
         let plistData = try encoder.encode(item)
         #if os(Windows)
@@ -797,15 +797,11 @@ public struct FileSystem: FileSysteming, Sendable {
         _ item: some Encodable,
         at path: Path.AbsolutePath,
         encoder: JSONEncoder,
-        options: Set<WriteJSONOptions>
+        options _: Set<WriteJSONOptions>
     ) async throws {
         logger?.debug("Writing .json at path \(path.pathString).")
 
         let json = try encoder.encode(item)
-        if options.contains(.overwrite), try await exists(path) {
-            try await remove(path)
-        }
-
         #if os(Windows)
             try json.write(to: URL(fileURLWithPath: path.pathString))
         #else

--- a/Tests/FileSystemTests/FileSystemTests.swift
+++ b/Tests/FileSystemTests/FileSystemTests.swift
@@ -150,6 +150,39 @@ private struct TestError: Error, Equatable {}
             }
         }
 
+        func test_makeDirectory_concurrentCreationOfTheSameDirectory() async throws {
+            try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+                // Given — pin the mkdir -p contract: parallel creation of the same target is race-safe.
+                let directoryPath = temporaryDirectory.appending(components: "parent", "shared", "target")
+
+                // When — many tasks race to create the exact same directory
+                var errors: [Error] = []
+                await withTaskGroup(of: Error?.self) { group in
+                    for _ in 0 ..< 50 {
+                        group.addTask {
+                            do {
+                                try await self.subject.makeDirectory(
+                                    at: directoryPath,
+                                    options: [.createTargetParentDirectories]
+                                )
+                                return nil
+                            } catch {
+                                return error
+                            }
+                        }
+                    }
+                    for await error in group {
+                        if let error { errors.append(error) }
+                    }
+                }
+
+                // Then — none of them should have failed
+                XCTAssertTrue(errors.isEmpty, "Concurrent makeDirectory failed: \(errors)")
+                let exists = try await subject.exists(directoryPath, isDirectory: true)
+                XCTAssertTrue(exists)
+            }
+        }
+
         func test_makeDirectory_concurrentCreationOfSharedIntermediateDirectories() async throws {
             try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
                 // Given
@@ -200,6 +233,75 @@ private struct TestError: Error, Equatable {}
 
                 // Then
                 XCTAssertEqual(got, "test")
+            }
+        }
+
+        func test_writeText_isRaceFreeUnderConcurrency() async throws {
+            try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+                // Given
+                let filePath = temporaryDirectory.appending(component: "concurrent-text")
+
+                // When — many tasks race to write the same path with both option sets
+                var errors: [Error] = []
+                await withTaskGroup(of: Error?.self) { group in
+                    for index in 0 ..< 50 {
+                        group.addTask {
+                            do {
+                                let options: Set<WriteTextOptions> = index.isMultiple(of: 2) ? [.overwrite] : []
+                                try await self.subject.writeText("hello", at: filePath, options: options)
+                                return nil
+                            } catch {
+                                return error
+                            }
+                        }
+                    }
+                    for await error in group {
+                        if let error { errors.append(error) }
+                    }
+                }
+
+                // Then — none of them should have failed; final content is intact
+                XCTAssertTrue(errors.isEmpty, "Concurrent writeText failed: \(errors)")
+                let content = try await subject.readTextFile(at: filePath)
+                XCTAssertEqual(content, "hello")
+            }
+        }
+
+        func test_writeAsJSON_isRaceFreeUnderConcurrency() async throws {
+            try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+                // Given
+                struct Payload: Codable, Equatable { let value: String }
+                let filePath = temporaryDirectory.appending(component: "concurrent.json")
+                let payload = Payload(value: "hello")
+
+                // When
+                var errors: [Error] = []
+                await withTaskGroup(of: Error?.self) { group in
+                    for index in 0 ..< 50 {
+                        group.addTask {
+                            do {
+                                let options: Set<WriteJSONOptions> = index.isMultiple(of: 2) ? [.overwrite] : []
+                                try await self.subject.writeAsJSON(
+                                    payload,
+                                    at: filePath,
+                                    encoder: JSONEncoder(),
+                                    options: options
+                                )
+                                return nil
+                            } catch {
+                                return error
+                            }
+                        }
+                    }
+                    for await error in group {
+                        if let error { errors.append(error) }
+                    }
+                }
+
+                // Then
+                XCTAssertTrue(errors.isEmpty, "Concurrent writeAsJSON failed: \(errors)")
+                let decoded: Payload = try await subject.readJSONFile(at: filePath)
+                XCTAssertEqual(decoded, payload)
             }
         }
 


### PR DESCRIPTION
## Summary

`writeText`, `writeAsPlist`, and `writeAsJSON` previously did the following when `.overwrite` was set:

```swift
if options.contains(.overwrite), try await exists(path) {
    try await remove(path)
}
// then write
```

The pre-check is both redundant and racy. The underlying writes (atomic write on POSIX via `File.System.Write.Atomic.write` with `.replaceExisting`, `Data.write` on Windows) already replace existing files atomically. Two concurrent writers could both pass the `exists` check, and the second `remove` would then fail.

Drop the dance. Behavior is preserved (writes still overwrite), the race is gone. The `.overwrite` enum cases are kept so the public API is unchanged.

Also extends the doc comment on `MakeDirectoryOptions.createTargetParentDirectories` to make full `mkdir -p` semantics explicit — including idempotency for an existing target directory, which the swift-file-system POSIX backend already provides — and adds a regression test pinning that contract under 50 parallel tasks racing to create the same target.

## Test plan

- [x] New concurrency test covering `writeText` (mixed `.overwrite`/no-options) under 50 parallel writers.
- [x] New concurrency test covering `writeAsJSON` under 50 parallel writers.
- [x] New regression test for `makeDirectory(...,[.createTargetParentDirectories])` under 50 parallel tasks racing to create the same target path.
- [x] `swift test` — 91 tests, 0 failures (macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)