### PR TITLE
feat: add exclude parameter to glob

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -225,6 +225,7 @@ let packageTargets: [Target] = [
         name: "FileSystemTests",
         dependencies: [
             "FileSystem",
+            "Glob",
         ]
     ),
     .target(

--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -345,11 +345,29 @@ public protocol FileSysteming: Sendable {
     #endif
 
     /// Looks up files and directories that match a set of glob patterns.
+    ///
+    /// The results omit the paths that match `FileSystem.defaultGlobExclusions`. Use
+    /// ``glob(directory:include:exclude:)`` to control which paths are excluded.
     /// - Parameters:
     ///   - directory: Base absolute directory that glob patterns are relative to.
     ///   - include: A list of glob patterns.
     /// - Returns: An async sequence to get the results.
     func glob(directory: Path.AbsolutePath, include: [String]) throws -> AnyThrowingAsyncSequenceable<Path.AbsolutePath>
+
+    /// Looks up files and directories that match a set of glob patterns, omitting the ones that
+    /// match `exclude`.
+    /// - Parameters:
+    ///   - directory: Base absolute directory that glob patterns are relative to.
+    ///   - include: A list of glob patterns.
+    ///   - exclude: A list of glob patterns whose matches are omitted from the results. Pass an
+    ///   empty array to also get the paths that `FileSystem.defaultGlobExclusions` filters out,
+    ///   such as `.DS_Store` and `.gitkeep`.
+    /// - Returns: An async sequence to get the results.
+    func glob(
+        directory: Path.AbsolutePath,
+        include: [String],
+        exclude: [String]
+    ) throws -> AnyThrowingAsyncSequenceable<Path.AbsolutePath>
 
     /// Returns the path of the current working directory.
     func currentWorkingDirectory() async throws -> AbsolutePath
@@ -1116,24 +1134,26 @@ public struct FileSystem: FileSysteming, Sendable {
         }
     #endif
 
-    private func expandBraces(in regexString: String) throws -> [String] {
-        let pattern = #"\{[^}]+\}"#
-        let regex = try Regex(pattern)
-
-        guard let match = regexString.firstMatch(of: regex) else {
-            return [regexString]
-        }
-
-        return regexString[match.range]
-            .dropFirst()
-            .dropLast()
-            .split(separator: ",")
-            .map { option in
-                regexString.replacingCharacters(in: match.range, with: option)
-            }
-    }
+    /// The glob patterns that ``glob(directory:include:)`` omits from its results.
+    ///
+    /// These editor and version-control placeholder files are filtered out by default because
+    /// callers rarely want them. Pass an explicit `exclude` to
+    /// ``glob(directory:include:exclude:)`` to override the default, either to filter out
+    /// additional paths or to opt out of the filtering entirely.
+    public static let defaultGlobExclusions: [String] = [
+        "**/.DS_Store",
+        "**/.gitkeep",
+    ]
 
     public func glob(directory: Path.AbsolutePath, include: [String]) throws -> AnyThrowingAsyncSequenceable<Path.AbsolutePath> {
+        try glob(directory: directory, include: include, exclude: Self.defaultGlobExclusions)
+    }
+
+    public func glob(
+        directory: Path.AbsolutePath,
+        include: [String],
+        exclude: [String]
+    ) throws -> AnyThrowingAsyncSequenceable<Path.AbsolutePath> {
         let logMessage =
             "Looking up files and directories from \(directory.pathString) that match the glob patterns \(include.joined(separator: ", "))."
         logger?.debug("\(logMessage)")
@@ -1144,10 +1164,9 @@ public struct FileSystem: FileSysteming, Sendable {
             include: try include
                 .flatMap { try expandBraces(in: $0) }
                 .map { try Pattern($0) },
-            exclude: [
-                try Pattern("**/.DS_Store"),
-                try Pattern("**/.gitkeep"),
-            ],
+            exclude: try exclude
+                .flatMap { try expandBraces(in: $0) }
+                .map { try Pattern($0) },
             skipHiddenFiles: false
         )
         .map {
@@ -1155,6 +1174,68 @@ public struct FileSystem: FileSysteming, Sendable {
             return try Path.AbsolutePath(validating: path)
         }
         .eraseToAnyThrowingAsyncSequenceable()
+    }
+}
+
+private func expandBraces(in regexString: String) throws -> [String] {
+    let pattern = #"\{[^}]+\}"#
+    let regex = try Regex(pattern)
+
+    guard let match = regexString.firstMatch(of: regex) else {
+        return [regexString]
+    }
+
+    return regexString[match.range]
+        .dropFirst()
+        .dropLast()
+        .split(separator: ",")
+        .map { option in
+            regexString.replacingCharacters(in: match.range, with: option)
+        }
+}
+
+extension FileSysteming {
+    /// Filters the results of ``glob(directory:include:)`` instead of passing the exclusions down
+    /// to the underlying search, so that conforming types get a working implementation without
+    /// having to provide one.
+    ///
+    /// Because it filters results that ``glob(directory:include:)`` already produced, it cannot
+    /// surface paths that the two-argument overload dropped. Conforming types whose
+    /// ``glob(directory:include:)`` omits paths of its own accord, as `FileSystem` does with
+    /// `FileSystem.defaultGlobExclusions`, should implement this method to honor `exclude` fully.
+    public func glob(
+        directory: Path.AbsolutePath,
+        include: [String],
+        exclude: [String]
+    ) throws -> AnyThrowingAsyncSequenceable<Path.AbsolutePath> {
+        let patterns = try exclude
+            .flatMap { try expandBraces(in: $0) }
+            .map { try Pattern($0) }
+        return try glob(directory: directory, include: include)
+            .excludingPaths(matching: patterns, relativeTo: directory)
+            .eraseToAnyThrowingAsyncSequenceable()
+    }
+}
+
+extension AsyncSequence where Element == Path.AbsolutePath, Self: Sendable {
+    /// Omits the elements that match any of `patterns` relative to `directory`, along with the
+    /// descendants of the directories that match, mirroring how the underlying glob search prunes
+    /// an excluded directory's subtree.
+    func excludingPaths(
+        matching patterns: [Pattern],
+        relativeTo directory: Path.AbsolutePath
+    ) -> AsyncFilterSequence<Self> {
+        filter { path in
+            guard !patterns.isEmpty else { return true }
+            var ancestor = ""
+            for component in path.relative(to: directory).pathString.split(separator: "/") {
+                ancestor = ancestor.isEmpty ? String(component) : "\(ancestor)/\(component)"
+                if patterns.contains(where: { $0.match(ancestor) }) {
+                    return false
+                }
+            }
+            return true
+        }
     }
 }
 

--- a/Tests/FileSystemTests/FileSystemTests.swift
+++ b/Tests/FileSystemTests/FileSystemTests.swift
@@ -1136,6 +1136,102 @@ private struct TestError: Error, Equatable {}
             }
         }
 
+        func test_glob_with_an_empty_exclude_returns_ds_store_and_git_keep() async throws {
+            try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+                // Given
+                let directory = temporaryDirectory.appending(component: "first")
+                let sourceFile = directory.appending(component: "file.swift")
+                let dsStore = directory.appending(component: ".DS_Store")
+                let gitKeep = directory.appending(component: ".gitkeep")
+                try await subject.makeDirectory(at: directory)
+                try await subject.touch(sourceFile)
+                try await subject.touch(dsStore)
+                try await subject.touch(gitKeep)
+
+                // When
+                let got = try await subject.glob(
+                    directory: temporaryDirectory,
+                    include: ["**"],
+                    exclude: []
+                )
+                .collect()
+                .sorted()
+
+                // Then
+                XCTAssertEqual(got, [directory, dsStore, gitKeep, sourceFile].sorted())
+            }
+        }
+
+        func test_glob_excludes_the_paths_matching_the_exclude_patterns() async throws {
+            try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+                // Given
+                let directory = temporaryDirectory.appending(component: "first")
+                let sourceFile = directory.appending(component: "file.swift")
+                try await subject.makeDirectory(at: directory)
+                try await subject.touch(sourceFile)
+                try await subject.touch(directory.appending(component: "data.json"))
+
+                // When
+                let got = try await subject.glob(
+                    directory: temporaryDirectory,
+                    include: ["**"],
+                    exclude: ["**/*.json"]
+                )
+                .collect()
+                .sorted()
+
+                // Then
+                XCTAssertEqual(got, [directory, sourceFile].sorted())
+            }
+        }
+
+        func test_glob_excludes_the_descendants_of_an_excluded_directory() async throws {
+            try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+                // Given
+                let generatedDirectory = temporaryDirectory.appending(component: "Generated")
+                let sourceFile = temporaryDirectory.appending(component: "file.swift")
+                try await subject.makeDirectory(at: generatedDirectory)
+                try await subject.touch(generatedDirectory.appending(component: "generated.swift"))
+                try await subject.touch(sourceFile)
+
+                // When
+                let got = try await subject.glob(
+                    directory: temporaryDirectory,
+                    include: ["**"],
+                    exclude: ["Generated"]
+                )
+                .collect()
+                .sorted()
+
+                // Then
+                XCTAssertEqual(got, [sourceFile])
+            }
+        }
+
+        func test_glob_expands_braces_in_the_exclude_patterns() async throws {
+            try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+                // Given
+                let directory = temporaryDirectory.appending(component: "first")
+                let sourceFile = directory.appending(component: "file.swift")
+                try await subject.makeDirectory(at: directory)
+                try await subject.touch(sourceFile)
+                try await subject.touch(directory.appending(component: "data.json"))
+                try await subject.touch(directory.appending(component: "data.xml"))
+
+                // When
+                let got = try await subject.glob(
+                    directory: temporaryDirectory,
+                    include: ["**"],
+                    exclude: ["**/*.{json,xml}"]
+                )
+                .collect()
+                .sorted()
+
+                // Then
+                XCTAssertEqual(got, [directory, sourceFile].sorted())
+            }
+        }
+
         // Glob tests involving symlinks are skipped on Windows because symlinks require elevated permissions
         #if !os(Windows)
             func test_glob_with_symlink_and_only_a_directory_wildcard() async throws {

--- a/Tests/FileSystemTests/GlobExclusionTests.swift
+++ b/Tests/FileSystemTests/GlobExclusionTests.swift
@@ -1,0 +1,94 @@
+import Glob
+import Path
+import Testing
+@testable import FileSystem
+
+/// Covers the filtering that backs the default implementation of
+/// `glob(directory:include:exclude:)`, which conforming types get when they don't provide one.
+struct GlobExclusionTests {
+    private let directory = try! AbsolutePath(validating: "/root")
+
+    @Test func excludesThePathsMatchingThePatterns() async throws {
+        // Given
+        let sourceFile = directory.appending(try RelativePath(validating: "first/file.swift"))
+        let gitKeep = directory.appending(try RelativePath(validating: "first/.gitkeep"))
+
+        // When
+        let got = try await collect(
+            paths([sourceFile, gitKeep]).excludingPaths(
+                matching: [try Pattern("**/.gitkeep")],
+                relativeTo: directory
+            )
+        )
+
+        // Then
+        #expect(got == [sourceFile])
+    }
+
+    @Test func excludesTheDescendantsOfAnExcludedDirectory() async throws {
+        // Given
+        let generatedDirectory = directory.appending(try RelativePath(validating: "Generated"))
+        let generatedFile = directory.appending(try RelativePath(validating: "Generated/nested/generated.swift"))
+        let sourceFile = directory.appending(try RelativePath(validating: "file.swift"))
+
+        // When
+        let got = try await collect(
+            paths([generatedDirectory, generatedFile, sourceFile]).excludingPaths(
+                matching: [try Pattern("Generated")],
+                relativeTo: directory
+            )
+        )
+
+        // Then
+        #expect(got == [sourceFile])
+    }
+
+    @Test func keepsEveryPathWhenThereAreNoPatterns() async throws {
+        // Given
+        let gitKeep = directory.appending(try RelativePath(validating: "first/.gitkeep"))
+        let dsStore = directory.appending(try RelativePath(validating: ".DS_Store"))
+
+        // When
+        let got = try await collect(
+            paths([gitKeep, dsStore]).excludingPaths(matching: [], relativeTo: directory)
+        )
+
+        // Then
+        #expect(got == [gitKeep, dsStore])
+    }
+
+    @Test func keepsThePathsThatDoNotMatchThePatterns() async throws {
+        // Given
+        let sourceFile = directory.appending(try RelativePath(validating: "first/file.swift"))
+
+        // When
+        let got = try await collect(
+            paths([sourceFile]).excludingPaths(
+                matching: [try Pattern("**/*.json")],
+                relativeTo: directory
+            )
+        )
+
+        // Then
+        #expect(got == [sourceFile])
+    }
+
+    private func paths(_ paths: [AbsolutePath]) -> AsyncStream<AbsolutePath> {
+        AsyncStream { continuation in
+            for path in paths {
+                continuation.yield(path)
+            }
+            continuation.finish()
+        }
+    }
+
+    private func collect<S: AsyncSequence>(_ sequence: S) async throws -> [AbsolutePath]
+        where S.Element == AbsolutePath
+    {
+        var collected: [AbsolutePath] = []
+        for try await path in sequence {
+            collected.append(path)
+        }
+        return collected
+    }
+}


### PR DESCRIPTION
## What

Adds a `glob(directory:include:exclude:)` overload to `FileSysteming`, and expresses the current
filtering as `FileSystem.defaultGlobExclusions`, which the existing two-argument overload now
forwards to.

- Existing call sites keep their current results.
- Callers can extend the defaults, e.g. `exclude: FileSystem.defaultGlobExclusions + ["**/*.json"]`.
- Passing `exclude: []` opts out of the filtering entirely.
- Exclude patterns go through the same brace expansion as include patterns, so `**/*.{json,xml}`
  works in both.

## Why

`glob(directory:include:)` has filtered `.DS_Store` and `.gitkeep` out of its results since #115,
with no way for a caller to opt out. That is a good default, but it also makes those two filenames
unreachable through the API: a caller that deliberately targets them matches nothing, silently.

This currently blocks tuist/tuist#11534. A `.gitkeep` inside an Xcode buildable folder (a
synchronized root group) gets bundled into the build product, and several of them make the build
fail with "Multiple commands produce". Users cannot exclude them, because Tuist resolves
`BuildableFolderException.excluded` through `glob`, so a pattern like `["**/.gitkeep"]` expands to
an empty list. Xcode enumerates the synchronized folder itself, so Tuist cannot filter the file out
downstream either. Making the exclusions caller-controlled here is what unblocks that fix.

## Compatibility

Conforming types outside this package keep compiling. A protocol extension provides a default
implementation, so the new requirement does not need to be implemented. I verified this by
compiling Tuist's `MockFileSystem`, a 39-requirement conformer that implements only the
two-argument overload, against this branch without modifying it.

The default implementation filters the results of `glob(directory:include:)` instead of passing the
exclusions down to the search. It therefore cannot surface paths that the two-argument overload
already dropped, so `FileSystem` implements the method itself to honour `exclude` fully. That
trade-off is documented on the method. It stays a protocol requirement rather than an
extension-only method so dynamic dispatch reaches `FileSystem`'s implementation through a
`FileSysteming`-typed value.

The filtering also drops the descendants of an excluded directory, matching how the underlying
search prunes an excluded subtree via `skipDescendents`.

## Validation

- `mise run test-spm`: 95 XCTest and 19 Swift Testing tests, no failures.
- New tests: `exclude: []` returns `.DS_Store` and `.gitkeep`; custom patterns are excluded; brace
  expansion applies to exclude patterns; descendants of an excluded directory are omitted; plus
  unit tests for the filtering that backs the default implementation.
- The pre-existing tests asserting the default `.DS_Store` and `.gitkeep` filtering still pass, so
  behaviour is unchanged for current callers.
- `mise run lint` with the pinned swiftformat 0.52.10 and swiftlint 0.65.0: clean.
- `swift build --configuration release`: succeeds.

Checked everything only on Mac. The Linux and Windows jobs were not run locally. This change is platform agnostic.
