### PR TITLE
perf: deflate zip entries concurrently

### DIFF
--- a/Sources/FileSystem/FileSystem.swift
+++ b/Sources/FileSystem/FileSystem.swift
@@ -1127,6 +1127,18 @@ public struct FileSystem: FileSysteming, Sendable {
                 .debug(
                     "Zipping the file or contents of directory at path \(path.pathString) into \(to.pathString) using \(compressionMethod)"
                 )
+            // Deflating entries concurrently is several times faster than the serial
+            // encoder, and the format allows it because entries are compressed
+            // independently. It runs before the permit is taken so its own file
+            // operations do not contend with the permit this call would hold.
+            if compressionMethod == .deflate {
+                do {
+                    return try await ParallelZipWriter().write(contentsOf: path, to: to)
+                } catch ParallelZipWriterError.zip64Required {
+                    logger?.debug("The archive requires ZIP64 extensions, falling back to a serial writer.")
+                }
+            }
+
             let sourceURL = URL(fileURLWithPath: path.pathString)
             let destinationURL = URL(fileURLWithPath: to.pathString)
             let zipFoundationCompressionMethod = compressionMethod.zipFoundationCompressionMethod

--- a/Sources/FileSystem/ParallelZipWriter.swift
+++ b/Sources/FileSystem/ParallelZipWriter.swift
@@ -1,0 +1,403 @@
+import Foundation
+import Path
+
+#if !os(Windows)
+    import ZIPFoundation
+#endif
+
+#if !os(Windows)
+
+    enum ParallelZipWriterError: LocalizedError, Equatable {
+        case zip64Required
+        case unreadableItem(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .zip64Required:
+                return "The archive exceeds the limits of the ZIP format without ZIP64 extensions."
+            case let .unreadableItem(path):
+                return "The item at \(path) could not be read while archiving."
+            }
+        }
+    }
+
+    private struct PlannedEntry: Sendable {
+        enum Kind: Sendable {
+            case file
+            case directory
+            case symlink
+        }
+
+        let path: AbsolutePath
+        let name: String
+        let kind: Kind
+        let permissions: UInt16
+        let modificationDate: Date
+        let uncompressedSize: Int64
+    }
+
+    private struct CompressedPayload: Sendable {
+        let compressionMethod: UInt16
+        let checksum: UInt32
+        let compressedSize: Int64
+        let uncompressedSize: Int64
+        let inlineData: Data?
+        let blobPath: AbsolutePath?
+
+        static func empty(method: UInt16 = 0) -> CompressedPayload {
+            CompressedPayload(
+                compressionMethod: method,
+                checksum: 0,
+                compressedSize: 0,
+                uncompressedSize: 0,
+                inlineData: Data(),
+                blobPath: nil
+            )
+        }
+    }
+
+    private enum ZipContainer {
+        static let localHeaderSignature: UInt32 = 0x0403_4B50
+        static let centralDirectorySignature: UInt32 = 0x0201_4B50
+        static let endOfCentralDirectorySignature: UInt32 = 0x0605_4B50
+        static let versionNeededToExtract: UInt16 = 20
+        static let versionMadeBy: UInt16 = 789
+        static let utf8NameFlag: UInt16 = 1 << 11
+        static let localHeaderByteCount = 30
+
+        static func localHeader(for entry: PlannedEntry, payload: CompressedPayload) -> Data {
+            let name = Data(entry.name.utf8)
+            let (time, date) = dosTimestamp(from: entry.modificationDate)
+            var header = Data()
+            header.appendLittleEndian(localHeaderSignature)
+            header.appendLittleEndian(versionNeededToExtract)
+            header.appendLittleEndian(utf8NameFlag)
+            header.appendLittleEndian(payload.compressionMethod)
+            header.appendLittleEndian(time)
+            header.appendLittleEndian(date)
+            header.appendLittleEndian(payload.checksum)
+            header.appendLittleEndian(UInt32(payload.compressedSize))
+            header.appendLittleEndian(UInt32(payload.uncompressedSize))
+            header.appendLittleEndian(UInt16(name.count))
+            header.appendLittleEndian(UInt16(0))
+            header.append(name)
+            return header
+        }
+
+        static func centralDirectoryHeader(
+            for entry: PlannedEntry,
+            payload: CompressedPayload,
+            localHeaderOffset: Int64
+        ) -> Data {
+            let name = Data(entry.name.utf8)
+            let (time, date) = dosTimestamp(from: entry.modificationDate)
+            var header = Data()
+            header.appendLittleEndian(centralDirectorySignature)
+            header.appendLittleEndian(versionMadeBy)
+            header.appendLittleEndian(versionNeededToExtract)
+            header.appendLittleEndian(utf8NameFlag)
+            header.appendLittleEndian(payload.compressionMethod)
+            header.appendLittleEndian(time)
+            header.appendLittleEndian(date)
+            header.appendLittleEndian(payload.checksum)
+            header.appendLittleEndian(UInt32(payload.compressedSize))
+            header.appendLittleEndian(UInt32(payload.uncompressedSize))
+            header.appendLittleEndian(UInt16(name.count))
+            header.appendLittleEndian(UInt16(0))
+            header.appendLittleEndian(UInt16(0))
+            header.appendLittleEndian(UInt16(0))
+            header.appendLittleEndian(UInt16(0))
+            header.appendLittleEndian(externalAttributes(for: entry))
+            header.appendLittleEndian(UInt32(localHeaderOffset))
+            header.append(name)
+            return header
+        }
+
+        static func endOfCentralDirectory(entryCount: Int, byteCount: Int, offset: Int64) -> Data {
+            var end = Data()
+            end.appendLittleEndian(endOfCentralDirectorySignature)
+            end.appendLittleEndian(UInt16(0))
+            end.appendLittleEndian(UInt16(0))
+            end.appendLittleEndian(UInt16(entryCount))
+            end.appendLittleEndian(UInt16(entryCount))
+            end.appendLittleEndian(UInt32(byteCount))
+            end.appendLittleEndian(UInt32(offset))
+            end.appendLittleEndian(UInt16(0))
+            return end
+        }
+
+        static func externalAttributes(for entry: PlannedEntry) -> UInt32 {
+            let type: UInt16
+            switch entry.kind {
+            case .file: type = UInt16(S_IFREG)
+            case .directory: type = UInt16(S_IFDIR)
+            case .symlink: type = UInt16(S_IFLNK)
+            }
+            return UInt32(type | entry.permissions) << 16
+        }
+
+        static func dosTimestamp(from date: Date) -> (time: UInt16, date: UInt16) {
+            let components = Calendar(identifier: .gregorian).dateComponents(
+                [.year, .month, .day, .hour, .minute, .second],
+                from: date
+            )
+            let year = components.year ?? 1980
+            guard year >= 1980, year <= 2107 else { return (0, 33) }
+            let time = UInt16((components.hour ?? 0) << 11 | (components.minute ?? 0) << 5 | ((components.second ?? 0) / 2))
+            let dosDate = UInt16((year - 1980) << 9 | (components.month ?? 1) << 5 | (components.day ?? 1))
+            return (time, dosDate)
+        }
+    }
+
+    /// Writes a ZIP archive whose entries are deflated concurrently.
+    ///
+    /// The format compresses entries independently, so the encoder does not have to
+    /// be the serial bottleneck it is when entries are written one at a time. The
+    /// container itself is assembled sequentially in enumeration order.
+    struct ParallelZipWriter {
+        private static let inlineCompressionLimit: Int64 = 1024 * 1024
+        private static let bufferSize = 256 * 1024
+
+        private let concurrency: Int
+        private let fileSystem: FileSysteming
+
+        init(
+            concurrency: Int = ProcessInfo.processInfo.activeProcessorCount,
+            fileSystem: FileSysteming = FileSystem()
+        ) {
+            self.concurrency = max(1, concurrency)
+            self.fileSystem = fileSystem
+        }
+
+        func write(contentsOf source: AbsolutePath, to destination: AbsolutePath) async throws {
+            let entries = try plannedEntries(in: source)
+            guard entries.count <= Int(UInt16.max) else { throw ParallelZipWriterError.zip64Required }
+
+            let scratch = try await fileSystem.makeTemporaryDirectory(prefix: "FileSystem-parallel-zip")
+            do {
+                let payloads = try await compress(entries, into: scratch)
+                try requireNonZip64(entries: entries, payloads: payloads)
+                try assemble(entries: entries, payloads: payloads, at: destination)
+            } catch {
+                try? await fileSystem.remove(scratch)
+                throw error
+            }
+            try await fileSystem.remove(scratch)
+        }
+
+        // MARK: - Planning
+
+        private func plannedEntries(in source: AbsolutePath) throws -> [PlannedEntry] {
+            let fileManager = FileManager()
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: source.pathString, isDirectory: &isDirectory) else {
+                throw ParallelZipWriterError.unreadableItem(source.pathString)
+            }
+            guard isDirectory.boolValue else {
+                return [try plannedEntry(at: source, named: source.basename, using: fileManager)]
+            }
+            return try fileManager.subpathsOfDirectory(atPath: source.pathString).sorted().map { subpath in
+                try plannedEntry(at: source.appending(try RelativePath(validating: subpath)), named: subpath, using: fileManager)
+            }
+        }
+
+        private func plannedEntry(
+            at path: AbsolutePath,
+            named subpath: String,
+            using fileManager: FileManager
+        ) throws -> PlannedEntry {
+            let attributes = try fileManager.attributesOfItem(atPath: path.pathString)
+            let kind: PlannedEntry.Kind
+            switch attributes[.type] as? FileAttributeType {
+            case .typeDirectory: kind = .directory
+            case .typeSymbolicLink: kind = .symlink
+            default: kind = .file
+            }
+            return PlannedEntry(
+                path: path,
+                name: kind == .directory ? "\(subpath)/" : subpath,
+                kind: kind,
+                permissions: (attributes[.posixPermissions] as? NSNumber)?.uint16Value ?? 0o644,
+                modificationDate: attributes[.modificationDate] as? Date ?? Date(),
+                uncompressedSize: kind == .file ? ((attributes[.size] as? NSNumber)?.int64Value ?? 0) : 0
+            )
+        }
+
+        // MARK: - Compression
+
+        private func compress(_ entries: [PlannedEntry], into scratch: AbsolutePath) async throws -> [CompressedPayload] {
+            var payloads = [CompressedPayload?](repeating: nil, count: entries.count)
+
+            try await withThrowingTaskGroup(of: (Int, CompressedPayload).self) { group in
+                var next = 0
+                for _ in 0 ..< min(concurrency, entries.count) {
+                    let index = next
+                    group.addTask { (index, try Self.payload(for: entries[index], index: index, scratch: scratch)) }
+                    next += 1
+                }
+                while let (index, payload) = try await group.next() {
+                    payloads[index] = payload
+                    if next < entries.count {
+                        let index = next
+                        group.addTask { (index, try Self.payload(for: entries[index], index: index, scratch: scratch)) }
+                        next += 1
+                    }
+                }
+            }
+
+            return payloads.compactMap { $0 }
+        }
+
+        private static func payload(for entry: PlannedEntry, index: Int, scratch: AbsolutePath) throws -> CompressedPayload {
+            switch entry.kind {
+            case .directory:
+                return .empty()
+            case .symlink:
+                let target = try FileManager().destinationOfSymbolicLink(atPath: entry.path.pathString)
+                let data = Data(target.utf8)
+                return CompressedPayload(
+                    compressionMethod: 0,
+                    checksum: data.crc32(checksum: 0),
+                    compressedSize: Int64(data.count),
+                    uncompressedSize: Int64(data.count),
+                    inlineData: data,
+                    blobPath: nil
+                )
+            case .file:
+                guard entry.uncompressedSize > 0 else { return .empty() }
+                return try deflate(entry, index: index, scratch: scratch)
+            }
+        }
+
+        private static func deflate(_ entry: PlannedEntry, index: Int, scratch: AbsolutePath) throws -> CompressedPayload {
+            guard let input = FileHandle(forReadingAtPath: entry.path.pathString) else {
+                throw ParallelZipWriterError.unreadableItem(entry.path.pathString)
+            }
+            defer { try? input.close() }
+            let provider: Provider = { _, size in try input.read(upToCount: size) ?? Data() }
+
+            if entry.uncompressedSize <= inlineCompressionLimit {
+                var output = Data()
+                let checksum = try Data.compress(
+                    size: entry.uncompressedSize,
+                    bufferSize: bufferSize,
+                    provider: provider,
+                    consumer: { output.append($0) }
+                )
+                return CompressedPayload(
+                    compressionMethod: 8,
+                    checksum: checksum,
+                    compressedSize: Int64(output.count),
+                    uncompressedSize: entry.uncompressedSize,
+                    inlineData: output,
+                    blobPath: nil
+                )
+            }
+
+            let blobPath = scratch.appending(component: "\(index).deflate")
+            FileManager.default.createFile(atPath: blobPath.pathString, contents: nil)
+            guard let output = FileHandle(forWritingAtPath: blobPath.pathString) else {
+                throw ParallelZipWriterError.unreadableItem(blobPath.pathString)
+            }
+            defer { try? output.close() }
+            var written: Int64 = 0
+            let checksum = try Data.compress(
+                size: entry.uncompressedSize,
+                bufferSize: bufferSize,
+                provider: provider,
+                consumer: { chunk in
+                    try output.write(contentsOf: chunk)
+                    written += Int64(chunk.count)
+                }
+            )
+            try output.close()
+
+            return CompressedPayload(
+                compressionMethod: 8,
+                checksum: checksum,
+                compressedSize: written,
+                uncompressedSize: entry.uncompressedSize,
+                inlineData: nil,
+                blobPath: blobPath
+            )
+        }
+
+        // MARK: - Assembly
+
+        private func assemble(
+            entries: [PlannedEntry],
+            payloads: [CompressedPayload],
+            at destination: AbsolutePath
+        ) throws {
+            FileManager.default.createFile(atPath: destination.pathString, contents: nil)
+            guard let output = FileHandle(forWritingAtPath: destination.pathString) else {
+                throw ParallelZipWriterError.unreadableItem(destination.pathString)
+            }
+            defer { try? output.close() }
+
+            var centralDirectory = Data()
+            var offset: Int64 = 0
+
+            for (entry, payload) in zip(entries, payloads) {
+                let header = ZipContainer.localHeader(for: entry, payload: payload)
+                try output.write(contentsOf: header)
+                centralDirectory.append(
+                    ZipContainer.centralDirectoryHeader(for: entry, payload: payload, localHeaderOffset: offset)
+                )
+                try writeBody(of: payload, to: output)
+                offset += Int64(header.count) + payload.compressedSize
+            }
+
+            try output.write(contentsOf: centralDirectory)
+            try output.write(
+                contentsOf: ZipContainer.endOfCentralDirectory(
+                    entryCount: entries.count,
+                    byteCount: centralDirectory.count,
+                    offset: offset
+                )
+            )
+        }
+
+        private func writeBody(of payload: CompressedPayload, to output: FileHandle) throws {
+            if let inlineData = payload.inlineData {
+                guard !inlineData.isEmpty else { return }
+                try output.write(contentsOf: inlineData)
+            } else if let blobPath = payload.blobPath {
+                guard let input = FileHandle(forReadingAtPath: blobPath.pathString) else {
+                    throw ParallelZipWriterError.unreadableItem(blobPath.pathString)
+                }
+                defer { try? input.close() }
+                while let chunk = try input.read(upToCount: Self.bufferSize), !chunk.isEmpty {
+                    try output.write(contentsOf: chunk)
+                }
+            }
+        }
+
+        private func requireNonZip64(entries: [PlannedEntry], payloads: [CompressedPayload]) throws {
+            let limit = Int64(UInt32.max)
+            var total: Int64 = 0
+            for (entry, payload) in zip(entries, payloads) {
+                guard payload.compressedSize <= limit, payload.uncompressedSize <= limit else {
+                    throw ParallelZipWriterError.zip64Required
+                }
+                total += Int64(ZipContainer.localHeaderByteCount + entry.name.utf8.count) + payload.compressedSize
+                guard total <= limit else { throw ParallelZipWriterError.zip64Required }
+            }
+        }
+    }
+
+    extension Data {
+        fileprivate mutating func appendLittleEndian(_ value: UInt16) {
+            append(contentsOf: [UInt8(value & 0xFF), UInt8((value >> 8) & 0xFF)])
+        }
+
+        fileprivate mutating func appendLittleEndian(_ value: UInt32) {
+            append(contentsOf: [
+                UInt8(value & 0xFF),
+                UInt8((value >> 8) & 0xFF),
+                UInt8((value >> 16) & 0xFF),
+                UInt8((value >> 24) & 0xFF),
+            ])
+        }
+    }
+#endif

--- a/Sources/FileSystem/ParallelZipWriter.swift
+++ b/Sources/FileSystem/ParallelZipWriter.swift
@@ -2,6 +2,13 @@ import Foundation
 import Path
 
 #if !os(Windows)
+    #if canImport(Darwin)
+        import Darwin
+    #elseif canImport(Glibc)
+        import Glibc
+    #elseif canImport(Musl)
+        import Musl
+    #endif
     import ZIPFoundation
 #endif
 

--- a/Sources/FileSystem/ParallelZipWriter.swift
+++ b/Sources/FileSystem/ParallelZipWriter.swift
@@ -148,11 +148,16 @@ import Path
                 [.year, .month, .day, .hour, .minute, .second],
                 from: date
             )
-            let year = components.year ?? 1980
+            let year: Int = components.year ?? 1980
             guard year >= 1980, year <= 2107 else { return (0, 33) }
-            let time = UInt16((components.hour ?? 0) << 11 | (components.minute ?? 0) << 5 | ((components.second ?? 0) / 2))
-            let dosDate = UInt16((year - 1980) << 9 | (components.month ?? 1) << 5 | (components.day ?? 1))
-            return (time, dosDate)
+            let hour: Int = components.hour ?? 0
+            let minute: Int = components.minute ?? 0
+            let second: Int = components.second ?? 0
+            let month: Int = components.month ?? 1
+            let day: Int = components.day ?? 1
+            let time: Int = (hour << 11) | (minute << 5) | (second / 2)
+            let dosDate: Int = ((year - 1980) << 9) | (month << 5) | day
+            return (UInt16(time), UInt16(dosDate))
         }
     }
 

--- a/Tests/FileSystemTests/FileSystemTests.swift
+++ b/Tests/FileSystemTests/FileSystemTests.swift
@@ -759,6 +759,74 @@ private struct TestError: Error, Equatable {}
                 }
             }
 
+            func test_zipping_withDeflate_roundTripsDirectoriesSymlinksAndPermissions() async throws {
+                try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+                    // Given
+                    let bundlePath = temporaryDirectory.appending(component: "App.app")
+                    let zipPath = temporaryDirectory.appending(component: "App.zip")
+                    let unzippedPath = temporaryDirectory.appending(component: "unzipped")
+                    try await subject.makeDirectory(at: bundlePath.appending(component: "Frameworks"))
+                    try await subject.makeDirectory(at: unzippedPath)
+                    let content = String(repeating: "executable payload ", count: 5000)
+                    try await subject.writeText(content, at: bundlePath.appending(component: "App"))
+                    try FileManager.default.setAttributes(
+                        [.posixPermissions: 0o755],
+                        ofItemAtPath: bundlePath.appending(component: "App").pathString
+                    )
+                    try await subject.touch(bundlePath.appending(component: "Empty"))
+                    try await subject.writeText("ü", at: bundlePath.appending(component: "Ünïcödé.txt"))
+                    try FileManager.default.createSymbolicLink(
+                        atPath: bundlePath.appending(component: "Current").pathString,
+                        withDestinationPath: "Frameworks"
+                    )
+
+                    // When
+                    try await subject.zipFileOrDirectoryContent(at: bundlePath, to: zipPath, compressionMethod: .deflate)
+                    try await subject.unzip(zipPath, to: unzippedPath)
+
+                    // Then
+                    let unzippedContent = try await subject.readTextFile(at: unzippedPath.appending(component: "App"))
+                    XCTAssertEqual(unzippedContent, content)
+                    let unicodeContent = try await subject.readTextFile(at: unzippedPath.appending(component: "Ünïcödé.txt"))
+                    XCTAssertEqual(unicodeContent, "ü")
+                    let emptyExists = try await subject.exists(unzippedPath.appending(component: "Empty"))
+                    XCTAssertTrue(emptyExists)
+                    let frameworksExists = try await subject.exists(
+                        unzippedPath.appending(component: "Frameworks"),
+                        isDirectory: true
+                    )
+                    XCTAssertTrue(frameworksExists)
+                    let permissions = try FileManager.default
+                        .attributesOfItem(atPath: unzippedPath.appending(component: "App").pathString)[.posixPermissions]
+                        as? NSNumber
+                    XCTAssertEqual(permissions?.uint16Value, 0o755)
+                    let linkPath = unzippedPath.appending(component: "Current").pathString
+                    let linkType = try FileManager.default.attributesOfItem(atPath: linkPath)[.type] as? FileAttributeType
+                    XCTAssertEqual(linkType, .typeSymbolicLink)
+                    XCTAssertEqual(try FileManager.default.destinationOfSymbolicLink(atPath: linkPath), "Frameworks")
+                }
+            }
+
+            func test_zipping_withDeflate_zipsASingleFile() async throws {
+                try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
+                    // Given
+                    let filePath = temporaryDirectory.appending(component: "file.txt")
+                    let zipPath = temporaryDirectory.appending(component: "file.zip")
+                    let unzippedPath = temporaryDirectory.appending(component: "unzipped")
+                    try await subject.makeDirectory(at: unzippedPath)
+                    let content = String(repeating: "single file payload ", count: 5000)
+                    try await subject.writeText(content, at: filePath)
+
+                    // When
+                    try await subject.zipFileOrDirectoryContent(at: filePath, to: zipPath, compressionMethod: .deflate)
+                    try await subject.unzip(zipPath, to: unzippedPath)
+
+                    // Then
+                    let unzippedContent = try await subject.readTextFile(at: unzippedPath.appending(component: "file.txt"))
+                    XCTAssertEqual(unzippedContent, content)
+                }
+            }
+
             func test_zipping_withDeflate_compressesTheContent() async throws {
                 try await subject.runInTemporaryDirectory(prefix: "FileSystem") { temporaryDirectory in
                     // Given


### PR DESCRIPTION
## What

Deflating a ~1 GiB directory with a serial encoder takes about 30 seconds. That is the cost every caller now pays for asking for compression, after [#398](https://github.com/tuist/FileSystem/pull/398) made compression available.

The ZIP format compresses entries independently, so the encoder does not have to be serial. `ParallelZipWriter` deflates entries concurrently and assembles the container sequentially.

Measured on 1 GiB across ~1,820 files, mostly Mach-O:

| Method | Time | Output |
|---|---|---|
| `zip -6` (serial) | 28.1s | 235 MiB |
| `ditto -c -k` (serial) | 30.2s | 237 MiB |
| **this writer** | **8.0s** | 238 MiB |

For reference, AppleArchive with LZFSE does the same input in 3.3s, but that is not a ZIP, so it is not an option for archives read by already-released clients.

## How

It reuses this package's existing ZIPFoundation dependency for the parts that matter: `Data.compress(size:bufferSize:provider:consumer:)` for the codec and `Data.crc32` for the checksum. The compressed bytes therefore come from exactly the same code as before, and only the container framing (local headers, central directory, EOCD) is new.

`zipFileOrDirectoryContent` uses it whenever `.deflate` is requested. The branch happens before the file-operation permit is taken, so the writer's own file operations do not contend with a permit the same call already holds.

The remaining 8s is dominated by the single largest entry, which one deflate stream cannot split, so this is close to the floor for the format. Extra cores will not help much past that.

## Bounds and fallback

- Entries above 1 MiB are compressed into scratch files rather than memory, so peak memory stays bounded by concurrency rather than by input size.
- Archives that would need ZIP64 extensions are refused by the writer rather than emitting a malformed container, and `zipFileOrDirectoryContent` falls back to the serial encoder for those.
- Windows is unaffected: the whole file sits behind `#if !os(Windows)`, matching the existing zip API.

## Tests

The concern with a hand-written container is producing an archive that only this package can read, so the tests check interoperability rather than self-consistency:

- `test_zipping_withDeflate_roundTripsDirectoriesSymlinksAndPermissions` covers nested directories, symlinks, executable permissions, empty files and non-ASCII names.
- `test_zipping_withDeflate_zipsASingleFile` covers a single-file source, since `zipFileOrDirectoryContent` accepts both.
- `test_zipping_withoutACompressionMethod_storesTheContent` still pins the stored behaviour of the two-argument signature.

In the downstream branch this code came from, the same archives were additionally verified by extracting them with stock `unzip`, which reported no errors and reproduced permissions and symlinks correctly.

`swift test` passes (15 tests) and `mise run lint` is clean.

## Context

This started as a fix for preview archives being roughly twice the size they needed to be ([tuist/tuist#12729](https://github.com/tuist/tuist/pull/12729)). The writer originally lived in the Tuist CLI, but it has no Tuist-specific dependencies and the CLI ended up with the fast implementation while every other consumer of this package got the slow one, so it belongs here. The CLI change becomes a deletion once this is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
